### PR TITLE
iptables: handle catch-all reject rule added by centos7 firewalld

### DIFF
--- a/network/iptables.go
+++ b/network/iptables.go
@@ -40,6 +40,13 @@ type IPTablesRule struct {
 	rulespec []string
 }
 
+type IPTablesRulePos struct {
+	table    string
+	chain    string
+	pos      int
+	rulespec []string
+}
+
 func MasqRules(ipn ip.IP4Net, lease *subnet.Lease) []IPTablesRule {
 	n := ipn.String()
 	sn := lease.Subnet.String()
@@ -74,11 +81,17 @@ func MasqRules(ipn ip.IP4Net, lease *subnet.Lease) []IPTablesRule {
 	}
 }
 
-func ForwardRules(flannelNetwork string) []IPTablesRule {
+func RulesToInsert(chain string) []IPTablesRulePos {
+	return []IPTablesRulePos{
+		{"filter", "FORWARD", 1, []string{"-m", "comment", "--comment", "flannel forwarding rules", "-j", chain}},
+	}
+}
+
+func ForwardRules(chain, flannelNetwork string) []IPTablesRule {
 	return []IPTablesRule{
 		// These rules allow traffic to be forwarded if it is to or from the flannel network range.
-		{"filter", "FORWARD", []string{"-s", flannelNetwork, "-j", "ACCEPT"}},
-		{"filter", "FORWARD", []string{"-d", flannelNetwork, "-j", "ACCEPT"}},
+		{"filter", chain, []string{"-s", flannelNetwork, "-j", "ACCEPT"}},
+		{"filter", chain, []string{"-d", flannelNetwork, "-j", "ACCEPT"}},
 	}
 }
 
@@ -169,4 +182,34 @@ func teardownIPTables(ipt IPTables, rules []IPTablesRule) {
 		// doesn't exist, which is fine (we don't need to delete rules that don't exist)
 		ipt.Delete(rule.table, rule.chain, rule.rulespec...)
 	}
+}
+
+func AddNewChain(table, chain string) error {
+	ipt, err := iptables.New()
+	if err != nil {
+		// if we can't find iptables, give up and return
+		log.Errorf("Failed to setup IPTables. iptables binary was not found: %v", err)
+		return err
+	}
+	return ipt.ClearChain(table, chain)
+}
+
+func InsertRules(rules []IPTablesRulePos) error {
+	ipt, err := iptables.New()
+	if err != nil {
+		// if we can't find iptables, give up and return
+		log.Errorf("Failed to setup IPTables. iptables binary was not found: %v", err)
+		return err
+	}
+	for _, rule := range rules {
+		log.Info("Inserting iptables rule: ", strings.Join(rule.rulespec, " "))
+		// always remove the old entries first to avoid dulicate
+		ipt.Delete(rule.table, rule.chain, rule.rulespec...)
+		err := ipt.Insert(rule.table, rule.chain, rule.pos, rule.rulespec...)
+		if err != nil {
+			return fmt.Errorf("failed to insert IPTables rule: %v", err)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This is to fix issue reported in https://github.com/coreos/flannel/issues/1033.
In stead of appending two ACCEPT rules for pod network in the FORWARD chain, a new chain named "FLANNEL-FORWARD" is created and insert at the top of the FORWARD chain. The two ACCEPT rules for pod are appended to the new "FLANNEL-FORWARD" chain. This way the two ACCEPT rules will be matched first.

**Which issue(s) this PR fixes**:
Fixes #1033

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
