### PR TITLE
subnets: consider backend data during watch reset

### DIFF
--- a/subnet/watch.go
+++ b/subnet/watch.go
@@ -15,6 +15,7 @@
 package subnet
 
 import (
+	"bytes"
 	"time"
 
 	log "github.com/golang/glog"
@@ -76,7 +77,7 @@ func (lw *leaseWatcher) reset(leases []Lease) []Event {
 
 		found := false
 		for i, ol := range lw.leases {
-			if ol.Subnet.Equal(nl.Subnet) {
+			if ol.Subnet.Equal(nl.Subnet) && bytes.Compare(ol.Attrs.BackendData, nl.Attrs.BackendData) == 0 {
 				lw.leases = deleteLease(lw.leases, i)
 				found = true
 				break
@@ -89,7 +90,7 @@ func (lw *leaseWatcher) reset(leases []Lease) []Event {
 		}
 	}
 
-	// everything left in sm.leases has been deleted
+	// everything left in lw.leases has been deleted
 	for _, l := range lw.leases {
 		if lw.ownLease != nil && l.Subnet.Equal(lw.ownLease.Subnet) {
 			continue

--- a/subnet/watch.go
+++ b/subnet/watch.go
@@ -77,9 +77,13 @@ func (lw *leaseWatcher) reset(leases []Lease) []Event {
 
 		found := false
 		for i, ol := range lw.leases {
-			if ol.Subnet.Equal(nl.Subnet) && bytes.Compare(ol.Attrs.BackendData, nl.Attrs.BackendData) == 0 {
+			if ol.Subnet.Equal(nl.Subnet) {
 				lw.leases = deleteLease(lw.leases, i)
-				found = true
+
+				// If the backend data has changed, send the added event to the backend
+				if bytes.Compare(ol.Attrs.BackendData, nl.Attrs.BackendData) == 0 {
+					found = true
+				}
 				break
 			}
 		}


### PR DESCRIPTION
This fixes an issue we encountered, where if an etcd watch is reset
flannel can miss processing a mac address change when using the vxlan
backend. For a subnet lease to be considered equal during watch reset
the backend data must also be unchanged.


Type of fix: Bug fix
Testing completed: make test

## Todos
- [x] Still setting up tests to trigger the specific scenario within our clusters, so I'm submitting this ahead of that testing incase the change stands out as potentially incorrect to a reviewer.

Edit: manual testing of the fix under triggered conditions is working.
Steps to reproduce:
1. Use iptables to block connectivity to etcd: `iptables -I INPUT 1 -p tcp --source-port 2379 -j DROP && iptables -I OUTPUT 1 -p tcp --destination-port 2379 -j DROP`
2. Restart flannel on another cluster node with a reset mac address (delete flannel.1 or reboot the node)
3. Generate etcd traffic to advance the history window
4. Remove the iptables rule and observe the reconnection: `iptables -D INPUT 1 && iptables -D OUTPUT 1`

Observed Results:
```
Feb 03 20:57:15 kevin-test5 flanneld[29475]: E0203 20:57:15.959398   29475 watch.go:44] Watch subnets: client: etcd cluster is unavailable or misconfigured; error #0: read tcp 127.0.0.1:58562->127.0.0.1:2379: read: connection timed out
Feb 03 20:57:16 kevin-test5 flanneld[29475]: W0203 20:57:16.968459   29475 local_manager.go:345] Watch of subnet leases failed because etcd index outside history window
Feb 03 20:57:16 kevin-test5 flanneld[29475]: I0203 20:57:16.971181   29475 vxlan_network.go:138] adding subnet: 100.96.65.0/24 PublicIP: 10.162.0.6 VtepMAC: 5a:74:8f:aa:32:9f
Feb 03 20:57:16 kevin-test5 flanneld[29475]: I0203 20:57:16.971415   29475 vxlan_network.go:138] adding subnet: 100.96.74.0/24 PublicIP: 10.162.0.5 VtepMAC: 7e:09:75:b5:22:92
Feb 03 20:57:16 kevin-test5 flanneld[29475]: I0203 20:57:16.971502   29475 vxlan_network.go:138] adding subnet: 100.96.53.0/24 PublicIP: 10.162.0.7 VtepMAC: 8a:2b:5a:10:09:58
Feb 03 20:57:36 kevin-test5 flanneld[29475]: E0203 20:57:36.439379   29475 watch.go:176] Subnet watch failed: client: etcd cluster is unavailable or misconfigured; error #0: read tcp 127.0.0.1:58560->127.0.0.1:2379: read: connection timed out
Feb 03 20:57:37 kevin-test5 flanneld[29475]: W0203 20:57:37.448334   29475 local_manager.go:317] Watch of subnet leases failed because etcd index outside history window
Feb 03 20:57:37 kevin-test5 flanneld[29475]: I0203 20:57:37.451540   29475 main.go:418] Waiting for 22h3m40.997388723s to renew lease
```
* In the above example I restarted 3 nodes, matching the added events above.
