### PR TITLE
Use iptables-restore to preserve order with MASQ & FORWARD rules

### DIFF
--- a/main.go
+++ b/main.go
@@ -339,7 +339,7 @@ func main() {
 				os.Exit(1)
 			}
 			log.Infof("Setting up masking rules")
-			go network.SetupAndEnsureIPTables(network.MasqRules(config.Network, bn.Lease()), opts.iptablesResyncSeconds)
+			go network.SetupAndEnsureIP4Tables(network.MasqRules(config.Network, bn.Lease()), opts.iptablesResyncSeconds)
 
 		}
 		if config.EnableIPv6 {
@@ -360,7 +360,7 @@ func main() {
 	if opts.iptablesForwardRules {
 		if config.EnableIPv4 {
 			log.Infof("Changing default FORWARD chain policy to ACCEPT")
-			go network.SetupAndEnsureIPTables(network.ForwardRules(config.Network.String()), opts.iptablesResyncSeconds)
+			go network.SetupAndEnsureIP4Tables(network.ForwardRules(config.Network.String()), opts.iptablesResyncSeconds)
 		}
 		if config.EnableIPv6 {
 			log.Infof("IPv6: Changing default FORWARD chain policy to ACCEPT")
@@ -413,7 +413,7 @@ func recycleIPTables(nw ip.IP4Net, lease *subnet.Lease) error {
 		lease := &subnet.Lease{
 			Subnet: prevSubnet,
 		}
-		if err := network.DeleteIPTables(network.MasqRules(prevNetwork, lease)); err != nil {
+		if err := network.DeleteIP4Tables(network.MasqRules(prevNetwork, lease)); err != nil {
 			return err
 		}
 	}

--- a/network/iptables.go
+++ b/network/iptables.go
@@ -18,7 +18,6 @@ package network
 
 import (
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/coreos/go-iptables/iptables"
@@ -135,16 +134,73 @@ func ipTablesRulesExist(ipt IPTables, rules []IPTablesRule) (bool, error) {
 	return true, nil
 }
 
-func SetupAndEnsureIPTables(rules []IPTablesRule, resyncPeriod int) {
+// ipTablesCleanAndBuild create from a list of iptables rules a transaction (as string) for iptables-restore for ordering the rules that effectively running
+func ipTablesCleanAndBuild(ipt IPTables, rules []IPTablesRule) (IPTablesRestoreRules, error) {
+	tablesRules := IPTablesRestoreRules{}
+
+	// Build append and delete rules
+	for _, rule := range rules {
+		exists, err := ipt.Exists(rule.table, rule.chain, rule.rulespec...)
+		if err != nil {
+			// this shouldn't ever happen
+			return nil, fmt.Errorf("failed to check rule existence: %v", err)
+		}
+		if exists {
+			if _, ok := tablesRules[rule.table]; !ok {
+				tablesRules[rule.table] = []IPTablesRestoreRuleSpec{}
+			}
+			// if the rule exists it's safer to delete it and then create them
+			tablesRules[rule.table] = append(tablesRules[rule.table], append(IPTablesRestoreRuleSpec{"-D", rule.chain}, rule.rulespec...))
+		}
+		// with iptables-restore we can ensure that all rules created are in good order and have no external rule between them
+		tablesRules[rule.table] = append(tablesRules[rule.table], append(IPTablesRestoreRuleSpec{"-A", rule.chain}, rule.rulespec...))
+	}
+
+	return tablesRules, nil
+}
+
+// ipTablesBootstrap init iptables rules using iptables-restore (with some cleaning if some rules already exists)
+func ipTablesBootstrap(ipt IPTables, iptRestore IPTablesRestore, rules []IPTablesRule) error {
+	tablesRules, err := ipTablesCleanAndBuild(ipt, rules)
+	if err != nil {
+		// if we can't find iptables or if we can check existing rules, give up and return
+		return fmt.Errorf("failed to setup iptables-restore payload: %v", err)
+	}
+
+	log.V(6).Infof("trying to run iptables-restore < %+v", tablesRules)
+
+	err = iptRestore.ApplyWithoutFlush(tablesRules)
+	if err != nil {
+		return fmt.Errorf("failed to apply partial iptables-restore %v", err)
+	}
+
+	log.Infof("bootstrap done")
+
+	return nil
+}
+
+func SetupAndEnsureIP4Tables(rules []IPTablesRule, resyncPeriod int) {
 	ipt, err := iptables.New()
 	if err != nil {
 		// if we can't find iptables, give up and return
 		log.Errorf("Failed to setup IPTables. iptables binary was not found: %v", err)
 		return
 	}
+	iptRestore, err := NewIPTablesRestoreWithProtocol(iptables.ProtocolIPv4)
+	if err != nil {
+		// if we can't find iptables-restore, give up and return
+		log.Errorf("Failed to setup IPTables. iptables-restore binary was not found: %v", err)
+		return
+	}
+
+	err = ipTablesBootstrap(ipt, iptRestore, rules)
+	if err != nil {
+		// if we can't find iptables, give up and return
+		log.Errorf("Failed to bootstrap IPTables: %v", err)
+	}
 
 	defer func() {
-		err := teardownIPTables(ipt, rules)
+		err := teardownIPTables(ipt, iptRestore, rules)
 		if err != nil {
 			log.Errorf("Failed to tear down IPTables: %v", err)
 		}
@@ -152,7 +208,7 @@ func SetupAndEnsureIPTables(rules []IPTablesRule, resyncPeriod int) {
 
 	for {
 		// Ensure that all the iptables rules exist every 5 seconds
-		if err := ensureIPTables(ipt, rules); err != nil {
+		if err := ensureIPTables(ipt, iptRestore, rules); err != nil {
 			log.Errorf("Failed to ensure iptables rules: %v", err)
 		}
 
@@ -167,9 +223,21 @@ func SetupAndEnsureIP6Tables(rules []IPTablesRule, resyncPeriod int) {
 		log.Errorf("Failed to setup IP6Tables. iptables binary was not found: %v", err)
 		return
 	}
+	iptRestore, err := NewIPTablesRestoreWithProtocol(iptables.ProtocolIPv6)
+	if err != nil {
+		// if we can't find iptables, give up and return
+		log.Errorf("Failed to setup iptables-restore: %v", err)
+		return
+	}
+
+	err = ipTablesBootstrap(ipt, iptRestore, rules)
+	if err != nil {
+		// if we can't find iptables, give up and return
+		log.Errorf("Failed to bootstrap IPTables: %v", err)
+	}
 
 	defer func() {
-		err := teardownIPTables(ipt, rules)
+		err := teardownIPTables(ipt, iptRestore, rules)
 		if err != nil {
 			log.Errorf("Failed to tear down IPTables: %v", err)
 		}
@@ -177,7 +245,7 @@ func SetupAndEnsureIP6Tables(rules []IPTablesRule, resyncPeriod int) {
 
 	for {
 		// Ensure that all the iptables rules exist every 5 seconds
-		if err := ensureIPTables(ipt, rules); err != nil {
+		if err := ensureIPTables(ipt, iptRestore, rules); err != nil {
 			log.Errorf("Failed to ensure iptables rules: %v", err)
 		}
 
@@ -185,17 +253,23 @@ func SetupAndEnsureIP6Tables(rules []IPTablesRule, resyncPeriod int) {
 	}
 }
 
-// DeleteIPTables delete specified iptables rules
-func DeleteIPTables(rules []IPTablesRule) error {
+// DeleteIP4Tables delete specified iptables rules
+func DeleteIP4Tables(rules []IPTablesRule) error {
 	ipt, err := iptables.New()
 	if err != nil {
 		// if we can't find iptables, give up and return
 		log.Errorf("Failed to setup IPTables. iptables binary was not found: %v", err)
 		return err
 	}
-	err = teardownIPTables(ipt, rules)
+	iptRestore, err := NewIPTablesRestoreWithProtocol(iptables.ProtocolIPv4)
 	if err != nil {
-		log.Errorf("Failed to tear down IPTables: %v", err)
+		// if we can't find iptables, give up and return
+		log.Errorf("Failed to setup iptables-restore: %v", err)
+		return err
+	}
+	err = teardownIPTables(ipt, iptRestore, rules)
+	if err != nil {
+		log.Errorf("Failed to teardown iptables: %v", err)
 		return err
 	}
 	return nil
@@ -209,18 +283,25 @@ func DeleteIP6Tables(rules []IPTablesRule) error {
 		log.Errorf("Failed to setup IP6Tables. iptables binary was not found: %v", err)
 		return err
 	}
-	err = teardownIPTables(ipt, rules)
+
+	iptRestore, err := NewIPTablesRestoreWithProtocol(iptables.ProtocolIPv6)
 	if err != nil {
-		log.Errorf("Failed to tear down IPTables: %v", err)
+		// if we can't find iptables, give up and return
+		log.Errorf("Failed to setup iptables-restore: %v", err)
+		return err
+	}
+	err = teardownIPTables(ipt, iptRestore, rules)
+	if err != nil {
+		log.Errorf("Failed to teardown iptables: %v", err)
 		return err
 	}
 	return nil
 }
 
-func ensureIPTables(ipt IPTables, rules []IPTablesRule) error {
+func ensureIPTables(ipt IPTables, iptRestore IPTablesRestore, rules []IPTablesRule) error {
 	exists, err := ipTablesRulesExist(ipt, rules)
 	if err != nil {
-		return fmt.Errorf("Error checking rule existence: %v", err)
+		return fmt.Errorf("error checking rule existence: %v", err)
 	}
 	if exists {
 		// if all the rules already exist, no need to do anything
@@ -229,43 +310,34 @@ func ensureIPTables(ipt IPTables, rules []IPTablesRule) error {
 	// Otherwise, teardown all the rules and set them up again
 	// We do this because the order of the rules is important
 	log.Info("Some iptables rules are missing; deleting and recreating rules")
-	if err = teardownIPTables(ipt, rules); err != nil {
-		return fmt.Errorf("Error tearing down rules: %v", err)
-	}
-	if err = setupIPTables(ipt, rules); err != nil {
-		return fmt.Errorf("Error setting up rules: %v", err)
+	err = ipTablesBootstrap(ipt, iptRestore, rules)
+	if err != nil {
+		// if we can't find iptables, give up and return
+		return fmt.Errorf("error setting up rules: %v", err)
 	}
 	return nil
 }
 
-func setupIPTables(ipt IPTables, rules []IPTablesRule) error {
+func teardownIPTables(ipt IPTables, iptr IPTablesRestore, rules []IPTablesRule) error {
+	tablesRules := IPTablesRestoreRules{}
+
+	// Build delete rules to a transaction for iptables restore
 	for _, rule := range rules {
-		log.Info("Adding iptables rule: ", strings.Join(rule.rulespec, " "))
-		err := ipt.AppendUnique(rule.table, rule.chain, rule.rulespec...)
+		exists, err := ipt.Exists(rule.table, rule.chain, rule.rulespec...)
 		if err != nil {
-			return fmt.Errorf("failed to insert IPTables rule: %v", err)
+			// this shouldn't ever happen
+			return fmt.Errorf("failed to check rule existence: %v", err)
 		}
-	}
-
-	return nil
-}
-
-func teardownIPTables(ipt IPTables, rules []IPTablesRule) error {
-	for _, rule := range rules {
-		log.Info("Deleting iptables rule: ", strings.Join(rule.rulespec, " "))
-		err := ipt.Delete(rule.table, rule.chain, rule.rulespec...)
-		if err != nil {
-			e := err.(IPTablesError)
-			// If this error is because the rule is already deleted, the message from iptables will be
-			// "Bad rule (does a matching rule exist in that chain?)". These are safe to ignore.
-			// However other errors (like EAGAIN caused by other things not respecting the xtables.lock)
-			// should halt the ensure process.  Otherwise rules can get out of order when a rule we think
-			// is deleted is actually still in the chain.
-			// This will leave the rules incomplete until the next successful reconciliation loop.
-			if !e.IsNotExist() {
-				return err
+		if exists {
+			if _, ok := tablesRules[rule.table]; !ok {
+				tablesRules[rule.table] = []IPTablesRestoreRuleSpec{}
 			}
+			tablesRules[rule.table] = append(tablesRules[rule.table], append(IPTablesRestoreRuleSpec{"-D", rule.chain}, rule.rulespec...))
 		}
+	}
+	err := iptr.ApplyWithoutFlush(tablesRules) // ApplyWithoutFlush make a diff, Apply make a replace (desired state)
+	if err != nil {
+		return fmt.Errorf("unable to teardown iptables: %v", err)
 	}
 
 	return nil

--- a/network/iptables_restore.go
+++ b/network/iptables_restore.go
@@ -1,0 +1,207 @@
+// Copyright 2015 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build !windows
+// +build !windows
+
+package network
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/coreos/go-iptables/iptables"
+	"io"
+	log "k8s.io/klog"
+	"os/exec"
+	"regexp"
+	"strconv"
+)
+
+const (
+	ipTablesRestoreCmd  string = "iptables-restore"
+	ip6TablesRestoreCmd string = "ip6tables-restore"
+)
+
+// IPTablesRestore wrapper for iptables-restore
+type IPTablesRestore interface {
+	// ApplyWithoutFlush apply without flush chains
+	ApplyWithoutFlush(rules IPTablesRestoreRules) error
+}
+
+// ipTablesRestore internal type
+type ipTablesRestore struct {
+	path    string
+	proto   iptables.Protocol
+	hasWait bool
+}
+
+// IPTablesRestoreRules represents iptables-restore table block
+type IPTablesRestoreRules map[string][]IPTablesRestoreRuleSpec
+
+// IPTablesRestoreRuleSpec represents one rule spec delimited by space
+type IPTablesRestoreRuleSpec []string
+
+// NewIPTablesRestoreWithProtocol build new IPTablesRestore for supplied proto
+func NewIPTablesRestoreWithProtocol(protocol iptables.Protocol) (IPTablesRestore, error) {
+	cmd := getIptablesRestoreCommand(protocol)
+	path, err := exec.LookPath(cmd)
+	if err != nil {
+		return nil, err
+	}
+	hasWait, err := getIptablesRestoreSupport(path)
+	if err != nil {
+		return nil, err
+	}
+
+	ipt := ipTablesRestore{
+		path:    path,
+		proto:   protocol,
+		hasWait: hasWait,
+	}
+	return &ipt, nil
+}
+
+// ApplyWithoutFlush apply without flush chains
+func (iptr *ipTablesRestore) ApplyWithoutFlush(rules IPTablesRestoreRules) error {
+	payload := buildIPTablesRestorePayload(rules)
+
+	log.V(6).Infof("trying to run with payload %s", payload)
+	stdout, stderr, err := iptr.runWithOutput([]string{"--noflush"}, bytes.NewBuffer([]byte(payload)))
+	if err != nil {
+		return fmt.Errorf("unable to run iptables-restore (%s, %s): %v", stdout, stderr, err)
+	}
+	return nil
+}
+
+// runWithOutput runs an iptables command with the given arguments,
+// writing any stdout output to the given writer
+func (iptr *ipTablesRestore) runWithOutput(args []string, stdin io.Reader) (string, string, error) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	if iptr.hasWait {
+		args = append(args, "--wait")
+	}
+
+	cmd := exec.Command(iptr.path, args...)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.Stdin = stdin
+
+	if err := cmd.Run(); err != nil {
+		return "", "", err
+	}
+
+	return stdout.String(), stderr.String(), nil
+}
+
+// buildIPTablesRestorePayload build table/COMMIT payload
+func buildIPTablesRestorePayload(tableRules IPTablesRestoreRules) string {
+	iptablesRestorePayload := ""
+	for table, rules := range tableRules {
+		iptablesRestorePayload += "*" + table + "\n"
+
+		for _, lineRule := range rules {
+			// as iptables-restore use stdin if "--comment" then protect "the comment"
+			size := len(lineRule)
+			for i, rule := range lineRule {
+				if i > 0 && lineRule[i-1] == "--comment" {
+					iptablesRestorePayload += "\"" + rule + "\""
+				} else {
+					iptablesRestorePayload += rule
+				}
+
+				if i < size-1 {
+					iptablesRestorePayload += " "
+				} else {
+					iptablesRestorePayload += "\n"
+				}
+			}
+		}
+
+		iptablesRestorePayload += "COMMIT\n"
+	}
+	return iptablesRestorePayload
+}
+
+// getIptablesRestoreSupport get current iptables-restore support
+func getIptablesRestoreSupport(path string) (hasWait bool, err error) {
+	version, err := getIptablesRestoreVersionString(path)
+	if err != nil {
+		return false, err
+	}
+	v1, v2, v3, err := extractIptablesRestoreVersion(version)
+	if err != nil {
+		return false, err
+	}
+	return ipTablesHasWaitSupport(v1, v2, v3), nil
+}
+
+// Checks if an iptables-restore version is after 1.4.20, when --wait was added
+func ipTablesHasWaitSupport(v1, v2, v3 int) bool {
+	if v1 > 1 {
+		return true
+	}
+	if v1 == 1 && v2 > 6 {
+		return true
+	}
+	if v1 == 1 && v2 == 6 && v3 >= 2 {
+		return true
+	}
+	return false
+}
+
+// extractIptablesRestoreVersion returns the first three components of the iptables-restore version
+// e.g. "iptables-restore v1.3.66" would return (1, 3, 66, nil)
+func extractIptablesRestoreVersion(str string) (int, int, int, error) {
+	versionMatcher := regexp.MustCompile(`v([0-9]+)\.([0-9]+)\.([0-9]+)`)
+	result := versionMatcher.FindStringSubmatch(str)
+	if result == nil {
+		return 0, 0, 0, fmt.Errorf("no iptables-restore version found in string: %s", str)
+	}
+
+	v1, err := strconv.Atoi(result[1])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	v2, err := strconv.Atoi(result[2])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+
+	v3, err := strconv.Atoi(result[3])
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	return v1, v2, v3, nil
+}
+
+// getIptablesRestoreVersionString run iptables-restore --version
+func getIptablesRestoreVersionString(path string) (string, error) {
+	cmd := exec.Command(path, "--version")
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	err := cmd.Run()
+	if err != nil {
+		return "", fmt.Errorf("unable to find iptables-restore version: %v", err)
+	}
+	return out.String(), nil
+}
+
+// getIptablesRestoreCommand returns the correct command for the given proto, either "iptables-restore" or "ip6tables-restore".
+func getIptablesRestoreCommand(proto iptables.Protocol) string {
+	if proto == iptables.ProtocolIPv6 {
+		return ip6TablesRestoreCmd
+	}
+	return ipTablesRestoreCmd
+}

--- a/network/iptables_restore_test.go
+++ b/network/iptables_restore_test.go
@@ -1,0 +1,45 @@
+// Copyright 2015 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//go:build !windows
+// +build !windows
+
+package network
+
+import "testing"
+
+func TestRules(t *testing.T) {
+	baseRules := IPTablesRestoreRules{
+		"filter": []IPTablesRestoreRuleSpec{
+			{"-A", "INPUT", "-s", "127.0.0.1", "-d", "127.0.0.1", "-j", "RETURN"},
+			{"-A", "INPUT", "-s", "127.0.0.1", "!", "-d", "224.0.0.0/4", "-m", "comment", "--comment", "flanneld masq", "-j", "MASQUERADE", "--random-fully"},
+		},
+		"nat": []IPTablesRestoreRuleSpec{
+			{"-A", "INPUT", "-s", "127.0.0.1", "-d", "127.0.0.1", "-j", "RETURN"},
+			{"-A", "INPUT", "-s", "127.0.0.1", "!", "-d", "224.0.0.0/4", "-m", "comment", "--comment", "flanneld masq", "-j", "MASQUERADE", "--random-fully"},
+		},
+	}
+	expectedPayload := `*filter
+-A INPUT -s 127.0.0.1 -d 127.0.0.1 -j RETURN
+-A INPUT -s 127.0.0.1 ! -d 224.0.0.0/4 -m comment --comment "flanneld masq" -j MASQUERADE --random-fully
+COMMIT
+*nat
+-A INPUT -s 127.0.0.1 -d 127.0.0.1 -j RETURN
+-A INPUT -s 127.0.0.1 ! -d 224.0.0.0/4 -m comment --comment "flanneld masq" -j MASQUERADE --random-fully
+COMMIT
+`
+	payload := buildIPTablesRestorePayload(baseRules)
+	if payload != expectedPayload {
+		t.Errorf("iptables-restore payload not as expected. Expected: %#v, Actual: %#v", expectedPayload, payload)
+	}
+}


### PR DESCRIPTION
Use iptables-restore to preserve order with MASQ & FORWARD rules.

## Description
When anything happen when delete/append iptables rules, sometimes you can have your rules out of order.This PR use only iptables-restore to guaranty order in delete/append rules.

This close https://github.com/coreos/flannel/issues/1261 & https://github.com/coreos/flannel/issues/1146
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [X] Tests
- [x] Documentation (Needed?)
- [X] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
