### PR TITLE
doc: Add section about creating new docker network

### DIFF
--- a/Documentation/running.md
+++ b/Documentation/running.md
@@ -98,6 +98,12 @@ docker daemon --bip=${FLANNEL_SUBNET} --mtu=${FLANNEL_MTU} &
 
 Systemd users can use `EnvironmentFile` directive in the `.service` file to pull in `/run/flannel/subnet.env`
 
+If you want to leave default docker0 network as it is and instead create a new network that will be using flannel you do so like this:
+```bash
+source /run/flannel/subnet.env
+docker network create --attachable=true --subnet=${FLANNEL_SUBNET} -o "com.docker.network.driver.mtu"=${FLANNEL_MTU} flannel
+```
+
 ## CoreOS integration
 
 CoreOS ships with flannel integrated into the distribution.


### PR DESCRIPTION
Flannel doesn't need to replace deamon0 network in Docker and does work even if the you create new docker network that uses flannel.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Flannel when using with docker doesn't need to replace the default docker0 network, instead, it can be attached to a new docker network. I have added documentation for this type of workflow.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
