### PR TITLE
make images point to v0.14.0-rc1

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -166,7 +166,7 @@ spec:
       serviceAccountName: flannel
       initContainers:
       - name: install-cni
-        image: quay.io/coreos/flannel:v0.13.1-rc2
+        image: quay.io/coreos/flannel:v0.14.0-rc1
         command:
         - cp
         args:
@@ -180,7 +180,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: quay.io/coreos/flannel:v0.13.1-rc2
+        image: quay.io/coreos/flannel:v0.14.0-rc1
         command:
         - /opt/bin/flanneld
         args:


### PR DESCRIPTION
## Description
for release candidate v0.14.0-rc1

## Todos
- [x] Release note

## Release Note
Key commits:
fdef5949 Add tencent cloud VPC network support
26b1485e moving go modules to flannel-io/flannel and updating to go 1.16
bb5eed1a fix(windows): nil pointer panic
6c0ec9ab Preserve environment for extension backend
78035d0c Fix flannel hang if lease expired
15262f05 Documentation for the Flannel upgrade/downgrade procedure
31dbe1c5 Move from glog to klog
a85e1279 fix(host-gw): failed to restart if gateway hnsep existed
e5a30dae ipsec: use well known paths of charon daemon
ba8c2165 upgrade client-go to 1.19.4
43781301 move from juju/errors to pkg/errors
1a1b6f13 subnets: move forward the cursor to skip illegal subnet
aa2491d5 Fix Expired URL to Deploying Flannel with kubeadm
8a1bcf6f Modify kube-flannel.yaml to use rbac.authorization.k8s.io/v1
c2d3069c preserve AccessKey & AccessKeySecret environment on `sudo` fix some typo in doc.
1850b091 iptables: handle errors that prevent rule deletes
