### PR TITLE
Log all config created using CLI flags

### DIFF
--- a/main.go
+++ b/main.go
@@ -189,6 +189,9 @@ func main() {
 
 	flagutil.SetFlagsFromEnv(flannelFlags, "FLANNELD")
 
+	// Log the config set via CLI flags
+	log.Infof("CLI flags config: %+v", opts)
+
 	// Validate flags
 	if opts.subnetLeaseRenewMargin >= 24*60 || opts.subnetLeaseRenewMargin <= 0 {
 		log.Error("Invalid subnet-lease-renew-margin option, out of acceptable range")


### PR DESCRIPTION
## Description
When looking at the logs, it is impossible to say what values are passed as flags. This patch logs that which will help debugging. The output will be:
```
CLI flags config: {etcdEndpoints:http://127.0.0.1:4001,http://127.0.0.1:2379 etcdPrefix:/coreos.com/network etcdKeyfile: etcdCertfile: etcdCAFile: etcdUsername: etcdPassword: help:false version:false kubeSubnetMgr:true kubeApiUrl: kubeAnnotationPrefix:flannel.alpha.coreos.com kubeConfigFile: iface:[] ifaceRegex:[] ipMasq:true subnetFile:/run/flannel/subnet.env subnetDir: publicIP: subnetLeaseRenewMargin:60 healthzIP:0.0.0.0 healthzPort:0 charonExecutablePath: charonViciUri: iptablesResyncSeconds:5 iptablesForwardRules:true netConfPath:/etc/kube-flannel/net-conf.json}
``

```release-note
None required
```
Signed-off-by: Manuel Buil <mbuil@suse.com>