### PR TITLE
Do not require subnet calculation if kubeSubnetMgr

### DIFF
--- a/subnet/config.go
+++ b/subnet/config.go
@@ -45,67 +45,71 @@ func parseBackendType(be json.RawMessage) (string, error) {
 	return bt.Type, nil
 }
 
-func ParseConfig(s string) (*Config, error) {
+func ParseConfig(s string, calculate_subnet bool) (*Config, error) {
 	cfg := new(Config)
 	err := json.Unmarshal([]byte(s), cfg)
 	if err != nil {
 		return nil, err
 	}
 
-	if cfg.SubnetLen > 0 {
-		// SubnetLen needs to allow for a tunnel and bridge device on each host.
-		if cfg.SubnetLen > 30 {
-			return nil, errors.New("SubnetLen must be less than /31")
-		}
+	// Set subnet parameters in cfg (not needed if kube-subnet-mgr)
+	if calculate_subnet {
 
-		// SubnetLen needs to fit _more_ than twice into the Network.
-		// the first subnet isn't used, so splitting into two one only provide one usable host.
-		if cfg.SubnetLen < cfg.Network.PrefixLen+2 {
-			return nil, errors.New("Network must be able to accommodate at least four subnets")
-		}
-	} else {
-		// If the network is smaller than a /28 then the network isn't big enough for flannel so return an error.
-		// Default to giving each host at least a /24 (as long as the network is big enough to support at least four hosts)
-		// Otherwise, if the network is too small to give each host a /24 just split the network into four.
-		if cfg.Network.PrefixLen > 28 {
-			// Each subnet needs at least four addresses (/30) and the network needs to accommodate at least four
-			// since the first subnet isn't used, so splitting into two would only provide one usable host.
-			// So the min useful PrefixLen is /28
-			return nil, errors.New("Network is too small. Minimum useful network prefix is /28")
-		} else if cfg.Network.PrefixLen <= 22 {
-			// Network is big enough to give each host a /24
-			cfg.SubnetLen = 24
+		if cfg.SubnetLen > 0 {
+			// SubnetLen needs to allow for a tunnel and bridge device on each host.
+			if cfg.SubnetLen > 30 {
+				return nil, errors.New("SubnetLen must be less than /31")
+			}
+
+			// SubnetLen needs to fit _more_ than twice into the Network.
+			// the first subnet isn't used, so splitting into two one only provide one usable host.
+			if cfg.SubnetLen < cfg.Network.PrefixLen+2 {
+				return nil, errors.New("Network must be able to accommodate at least four subnets")
+			}
 		} else {
-			// Use +2 to provide four hosts per subnet.
-			cfg.SubnetLen = cfg.Network.PrefixLen + 2
+			// If the network is smaller than a /28 then the network isn't big enough for flannel so return an error.
+			// Default to giving each host at least a /24 (as long as the network is big enough to support at least four hosts)
+			// Otherwise, if the network is too small to give each host a /24 just split the network into four.
+			if cfg.Network.PrefixLen > 28 {
+				// Each subnet needs at least four addresses (/30) and the network needs to accommodate at least four
+				// since the first subnet isn't used, so splitting into two would only provide one usable host.
+				// So the min useful PrefixLen is /28
+				return nil, errors.New("Network is too small. Minimum useful network prefix is /28")
+			} else if cfg.Network.PrefixLen <= 22 {
+				// Network is big enough to give each host a /24
+				cfg.SubnetLen = 24
+			} else {
+				// Use +2 to provide four hosts per subnet.
+				cfg.SubnetLen = cfg.Network.PrefixLen + 2
+			}
 		}
-	}
 
-	subnetSize := ip.IP4(1 << (32 - cfg.SubnetLen))
+		subnetSize := ip.IP4(1 << (32 - cfg.SubnetLen))
 
-	if cfg.SubnetMin == ip.IP4(0) {
-		// skip over the first subnet otherwise it causes problems. e.g.
-		// if Network is 10.100.0.0/16, having an interface with 10.0.0.0
-		// conflicts with the broadcast address.
-		cfg.SubnetMin = cfg.Network.IP + subnetSize
-	} else if !cfg.Network.Contains(cfg.SubnetMin) {
-		return nil, errors.New("SubnetMin is not in the range of the Network")
-	}
+		if cfg.SubnetMin == ip.IP4(0) {
+			// skip over the first subnet otherwise it causes problems. e.g.
+			// if Network is 10.100.0.0/16, having an interface with 10.0.0.0
+			// conflicts with the broadcast address.
+			cfg.SubnetMin = cfg.Network.IP + subnetSize
+		} else if !cfg.Network.Contains(cfg.SubnetMin) {
+			return nil, errors.New("SubnetMin is not in the range of the Network")
+		}
 
-	if cfg.SubnetMax == ip.IP4(0) {
-		cfg.SubnetMax = cfg.Network.Next().IP - subnetSize
-	} else if !cfg.Network.Contains(cfg.SubnetMax) {
-		return nil, errors.New("SubnetMax is not in the range of the Network")
-	}
+		if cfg.SubnetMax == ip.IP4(0) {
+			cfg.SubnetMax = cfg.Network.Next().IP - subnetSize
+		} else if !cfg.Network.Contains(cfg.SubnetMax) {
+			return nil, errors.New("SubnetMax is not in the range of the Network")
+		}
 
-	// The SubnetMin and SubnetMax need to be aligned to a SubnetLen boundary
-	mask := ip.IP4(0xFFFFFFFF << (32 - cfg.SubnetLen))
-	if cfg.SubnetMin != cfg.SubnetMin&mask {
-		return nil, fmt.Errorf("SubnetMin is not on a SubnetLen boundary: %v", cfg.SubnetMin)
-	}
+		// The SubnetMin and SubnetMax need to be aligned to a SubnetLen boundary
+		mask := ip.IP4(0xFFFFFFFF << (32 - cfg.SubnetLen))
+		if cfg.SubnetMin != cfg.SubnetMin&mask {
+			return nil, fmt.Errorf("SubnetMin is not on a SubnetLen boundary: %v", cfg.SubnetMin)
+		}
 
-	if cfg.SubnetMax != cfg.SubnetMax&mask {
-		return nil, fmt.Errorf("SubnetMax is not on a SubnetLen boundary: %v", cfg.SubnetMax)
+		if cfg.SubnetMax != cfg.SubnetMax&mask {
+			return nil, fmt.Errorf("SubnetMax is not on a SubnetLen boundary: %v", cfg.SubnetMax)
+		}
 	}
 
 	bt, err := parseBackendType(cfg.Backend)

--- a/subnet/config_test.go
+++ b/subnet/config_test.go
@@ -21,7 +21,7 @@ import (
 func TestConfigDefaults(t *testing.T) {
 	s := `{ "network": "10.3.0.0/16" }`
 
-	cfg, err := ParseConfig(s)
+	cfg, err := ParseConfig(s, true)
 	if err != nil {
 		t.Fatalf("ParseConfig failed: %s", err)
 	}
@@ -47,7 +47,7 @@ func TestConfigDefaults(t *testing.T) {
 func TestConfigOverrides(t *testing.T) {
 	s := `{ "Network": "10.3.0.0/16", "SubnetMin": "10.3.5.0", "SubnetMax": "10.3.8.0", "SubnetLen": 28 }`
 
-	cfg, err := ParseConfig(s)
+	cfg, err := ParseConfig(s, true)
 	if err != nil {
 		t.Fatalf("ParseConfig failed: %s", err)
 	}
@@ -67,5 +67,31 @@ func TestConfigOverrides(t *testing.T) {
 
 	if cfg.SubnetLen != 28 {
 		t.Errorf("SubnetLen mismatch: expected 28, got %d", cfg.SubnetLen)
+	}
+}
+
+func TestConfigDefaultsNoSubnetCalculation(t *testing.T) {
+	s := `{ "network": "10.3.0.0/16" }`
+
+	cfg, err := ParseConfig(s, false)
+	if err != nil {
+		t.Fatalf("ParseConfig failed: %s", err)
+	}
+
+	expectedNet := "10.3.0.0/16"
+	if cfg.Network.String() != expectedNet {
+		t.Errorf("Network mismatch: expected %s, got %s", expectedNet, cfg.Network)
+	}
+
+	if cfg.SubnetMin.String() != "0.0.0.0" {
+		t.Errorf("SubnetMin mismatch, expected 0.0.0.0, got %s", cfg.SubnetMin)
+	}
+
+	if cfg.SubnetMax.String() != "0.0.0.0" {
+		t.Errorf("SubnetMax mismatch, expected 0.0.0.0, got %s", cfg.SubnetMax)
+	}
+
+	if cfg.SubnetLen != 0 {
+		t.Errorf("SubnetLen mismatch: expected 0, got %d", cfg.SubnetLen)
 	}
 }

--- a/subnet/etcdv2/local_manager.go
+++ b/subnet/etcdv2/local_manager.go
@@ -90,7 +90,7 @@ func (m *LocalManager) GetNetworkConfig(ctx context.Context) (*Config, error) {
 		return nil, err
 	}
 
-	return ParseConfig(cfg)
+	return ParseConfig(cfg, true)
 }
 
 func (m *LocalManager) AcquireLease(ctx context.Context, attrs *LeaseAttrs) (*Lease, error) {

--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -102,7 +102,7 @@ func NewSubnetManager(ctx context.Context, apiUrl, kubeconfig, prefix, netConfPa
 		return nil, fmt.Errorf("failed to read net conf: %v", err)
 	}
 
-	sc, err := subnet.ParseConfig(string(netConf))
+	sc, err := subnet.ParseConfig(string(netConf), false)
 	if err != nil {
 		return nil, fmt.Errorf("error parsing subnet config: %s", err)
 	}


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

## Description
When using kubeSubnetMgr, the subnet for each node is fetched from the podCIDR field of the node. Therefore, it is not needed to calculate the subnet based on parameters like SubnetLen, SubnetMin or SubnetMax.

This will help with the dual-stack PR 

## Todos
- [X] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
