### PR TITLE
Adding copy of flannel-cni binary to the host cni/bin folder

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -168,16 +168,16 @@ spec:
       - name: install-cni
         image: quay.io/coreos/flannel:v0.14.0
         command:
-        - cp
+        - /bin/sh
         args:
-        - -f
-        - /etc/kube-flannel/cni-conf.json
-        - /etc/cni/net.d/10-flannel.conflist
+        - [ '-c', 'cp -f /opt/bin/flannel /host/opt/cni/bin/flannel;cp -f /etc/kube-flannel/cni-conf.json /etc/cni/net.d/10-flannel.conflist' ]
         volumeMounts:
         - name: cni
           mountPath: /etc/cni/net.d
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
+        - name: host-cni
+          mountPath: /host/opt/cni/bin
       containers:
       - name: kube-flannel
         image: quay.io/coreos/flannel:v0.14.0
@@ -221,3 +221,6 @@ spec:
       - name: flannel-cfg
         configMap:
           name: kube-flannel-cfg
+      - name: host-cni
+        hostPath:
+          path: /opt/cni/bin/


### PR DESCRIPTION
## Description
Because flannel cni binary wouldn't be a part of upstream we need to copy it to the host on the first start
