### PR TITLE
fixing regex logic to get things compiling again, added windows funcs for ipv6 so it compiles

### DIFF
--- a/backend/alivpc/alivpc.go
+++ b/backend/alivpc/alivpc.go
@@ -18,7 +18,6 @@ package alivpc
 import (
 	"encoding/json"
 	"fmt"
-	"golang.org/x/net/context"
 	"os"
 	"sync"
 
@@ -28,6 +27,7 @@ import (
 	"github.com/flannel-io/flannel/backend"
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 	log "k8s.io/klog"
 )
 

--- a/backend/alivpc/alivpc_windows.go
+++ b/backend/alivpc/alivpc_windows.go
@@ -13,11 +13,3 @@
 // limitations under the License.
 
 package alivpc
-
-import (
-	log "k8s.io/klog"
-)
-
-func init() {
-	log.Infof("AliVpc is not supported on this platform")
-}

--- a/backend/awsvpc/awsvpc.go
+++ b/backend/awsvpc/awsvpc.go
@@ -26,11 +26,10 @@ import (
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/backend"
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 	log "k8s.io/klog"
 )
 

--- a/backend/awsvpc/awsvpc_windows.go
+++ b/backend/awsvpc/awsvpc_windows.go
@@ -13,11 +13,3 @@
 // limitations under the License.
 
 package awsvpc
-
-import (
-	log "k8s.io/klog"
-)
-
-func init() {
-	log.Infof("AWS VPC is not supported on this platform")
-}

--- a/backend/common.go
+++ b/backend/common.go
@@ -18,9 +18,8 @@ import (
 	"net"
 	"sync"
 
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 )
 
 type ExternalInterface struct {

--- a/backend/gce/gce_windows.go
+++ b/backend/gce/gce_windows.go
@@ -36,11 +36,3 @@
 // SOFTWARE.
 
 package gce
-
-import (
-	log "k8s.io/klog"
-)
-
-func init() {
-	log.Infof("GCE is not supported on this platform")
-}

--- a/backend/hostgw/hostgw.go
+++ b/backend/hostgw/hostgw.go
@@ -19,7 +19,6 @@ package hostgw
 
 import (
 	"fmt"
-
 	"sync"
 
 	"github.com/flannel-io/flannel/backend"

--- a/backend/ipip/ipip_windows.go
+++ b/backend/ipip/ipip_windows.go
@@ -14,11 +14,3 @@
 // +build windows
 
 package ipip
-
-import (
-	log "k8s.io/klog"
-)
-
-func init() {
-	log.Infof("ipip is not supported on this platform")
-}

--- a/backend/ipsec/ipsec_windows.go
+++ b/backend/ipsec/ipsec_windows.go
@@ -13,9 +13,3 @@
 // limitations under the License.
 
 package ipsec
-
-import log "k8s.io/klog"
-
-func init() {
-	log.Infof("ipsec is not supported on this platform")
-}

--- a/backend/manager.go
+++ b/backend/manager.go
@@ -19,9 +19,8 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 )
 
 var constructors = make(map[string]BackendCtor)

--- a/backend/route_network.go
+++ b/backend/route_network.go
@@ -22,10 +22,9 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/subnet"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/net/context"
 	log "k8s.io/klog"
 )
 

--- a/backend/route_network_windows.go
+++ b/backend/route_network_windows.go
@@ -19,10 +19,9 @@ import (
 	"sync"
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/pkg/routing"
 	"github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 	log "k8s.io/klog"
 )
 

--- a/backend/simple_network.go
+++ b/backend/simple_network.go
@@ -15,9 +15,8 @@
 package backend
 
 import (
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 )
 
 type SimpleNetwork struct {

--- a/backend/tencentvpc/tencentvpc_windows.go
+++ b/backend/tencentvpc/tencentvpc_windows.go
@@ -13,11 +13,3 @@
 // limitations under the License.
 
 package tencentvpc
-
-import (
-	log "k8s.io/klog"
-)
-
-func init() {
-	log.Infof("TencentVpc is not supported on this platform")
-}

--- a/backend/udp/udp_amd64.go
+++ b/backend/udp/udp_amd64.go
@@ -20,11 +20,10 @@ import (
 	"fmt"
 	"sync"
 
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/backend"
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 )
 
 func init() {

--- a/backend/udp/udp_network_amd64.go
+++ b/backend/udp/udp_network_amd64.go
@@ -24,12 +24,11 @@ import (
 	"sync"
 	"syscall"
 
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/backend"
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/subnet"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/net/context"
 	log "k8s.io/klog"
 )
 

--- a/backend/udp/udp_windows.go
+++ b/backend/udp/udp_windows.go
@@ -13,11 +13,3 @@
 // limitations under the License.
 
 package udp
-
-import (
-	log "k8s.io/klog"
-)
-
-func init() {
-	log.Infof("udp is not supported on this platform")
-}

--- a/backend/vxlan/vxlan.go
+++ b/backend/vxlan/vxlan.go
@@ -58,11 +58,10 @@ import (
 	"net"
 	"sync"
 
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/backend"
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 	log "k8s.io/klog"
 )
 

--- a/backend/vxlan/vxlan_network.go
+++ b/backend/vxlan/vxlan_network.go
@@ -21,12 +21,11 @@ import (
 	"sync"
 	"syscall"
 
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/backend"
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/subnet"
 	"github.com/vishvananda/netlink"
+	"golang.org/x/net/context"
 	log "k8s.io/klog"
 )
 

--- a/backend/vxlan/vxlan_network_windows.go
+++ b/backend/vxlan/vxlan_network_windows.go
@@ -20,12 +20,11 @@ import (
 	"strings"
 	"sync"
 
-	"golang.org/x/net/context"
-
 	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/flannel-io/flannel/backend"
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 	log "k8s.io/klog"
 )
 

--- a/backend/vxlan/vxlan_windows.go
+++ b/backend/vxlan/vxlan_windows.go
@@ -30,12 +30,11 @@ import (
 	"net"
 	"sync"
 
-	"golang.org/x/net/context"
-
 	"github.com/Microsoft/hcsshim/hcn"
 	"github.com/flannel-io/flannel/backend"
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 	log "k8s.io/klog"
 )
 

--- a/network/iptables_windows.go
+++ b/network/iptables_windows.go
@@ -31,21 +31,11 @@ type IPTablesRule struct {
 	rulespec []string
 }
 
-func MasqRules(ipn ip.IP4Net, lease *subnet.Lease) []IPTablesRule {
-	return nil
-}
-
-func ForwardRules(flannelNetwork string) []IPTablesRule {
-	return nil
-}
-
-func SetupAndEnsureIPTables(rules []IPTablesRule, resyncPeriod int) {
-
-}
-
-func DeleteIPTables(rules []IPTablesRule) error {
-	return nil
-}
-
-func teardownIPTables(ipt IPTables, rules []IPTablesRule) {
-}
+func MasqRules(ipn ip.IP4Net, lease *subnet.Lease) []IPTablesRule    { return nil }
+func ForwardRules(flannelNetwork string) []IPTablesRule              { return nil }
+func SetupAndEnsureIPTables(rules []IPTablesRule, resyncPeriod int)  {}
+func DeleteIPTables(rules []IPTablesRule) error                      { return nil }
+func teardownIPTables(ipt IPTables, rules []IPTablesRule)            {}
+func SetupAndEnsureIP6Tables(rules []IPTablesRule, resyncPeriod int) {}
+func MasqIP6Rules(ipn ip.IP6Net, lease *subnet.Lease) []IPTablesRule { return nil }
+func DeleteIP6Tables(rules []IPTablesRule) error                     { return nil }

--- a/pkg/ip/iface_windows.go
+++ b/pkg/ip/iface_windows.go
@@ -19,8 +19,9 @@ package ip
 import (
 	"errors"
 	"fmt"
-	"github.com/flannel-io/flannel/pkg/powershell"
 	"net"
+
+	"github.com/flannel-io/flannel/pkg/powershell"
 )
 
 // GetInterfaceIP4Addr returns the IPv4 address for the given network interface
@@ -143,3 +144,7 @@ func IsForwardingEnabledForInterface(iface *net.Interface) (bool, error) {
 
 	return powerShellJsonData.Forwarding == 1, nil
 }
+
+func GetInterfaceByIP6(ip net.IP) (*net.Interface, error)      { return nil, nil }
+func GetInterfaceIP6Addr(iface *net.Interface) (net.IP, error) { return nil, nil }
+func GetDefaultV6GatewayInterface() (*net.Interface, error)    { return nil, nil }

--- a/subnet/etcdv2/mock_registry.go
+++ b/subnet/etcdv2/mock_registry.go
@@ -20,11 +20,10 @@ import (
 	"time"
 
 	etcd "github.com/coreos/etcd/client"
-	"github.com/jonboulle/clockwork"
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/pkg/ip"
 	. "github.com/flannel-io/flannel/subnet"
+	"github.com/jonboulle/clockwork"
+	"golang.org/x/net/context"
 )
 
 var clock clockwork.Clock = clockwork.NewRealClock()

--- a/subnet/etcdv2/registry_test.go
+++ b/subnet/etcdv2/registry_test.go
@@ -21,10 +21,9 @@ import (
 	"time"
 
 	etcd "github.com/coreos/etcd/client"
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/pkg/ip"
 	. "github.com/flannel-io/flannel/subnet"
+	"golang.org/x/net/context"
 )
 
 func newTestEtcdRegistry(t *testing.T) (Registry, *mockEtcd) {

--- a/subnet/watch.go
+++ b/subnet/watch.go
@@ -17,9 +17,8 @@ package subnet
 import (
 	"time"
 
-	"golang.org/x/net/context"
-
 	"github.com/flannel-io/flannel/pkg/ip"
+	"golang.org/x/net/context"
 	log "k8s.io/klog"
 )
 

--- a/version/version.go
+++ b/version/version.go
@@ -14,4 +14,4 @@
 
 package version
 
-var Version = "0.5.3+git"
+var Version = "dev"


### PR DESCRIPTION
also removes the init func in ipsec for windows to remove unnecessary log if you do an empty import to get the backends initialized.