### PR TITLE
Add dual-stack support to the extension backend

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -83,7 +83,7 @@ Set `healthz-port` to a non-zero value will enable a healthz server for flannel.
 
 ## Dual-stack
 
-Flannel supports the dual-stack mode of Kubernetes. This means pods and services could use ipv4 and ipv6 at the same time. Currently, dual-stack is only supported for kube subnet manager and vxlan or host-gw(linux) backend.
+Flannel supports the dual-stack mode of Kubernetes. This means pods and services could use ipv4 and ipv6 at the same time. Currently, dual-stack is only supported for kube subnet manager and vxlan, extension or host-gw(linux) backend.
 
 Requirements:
 * v1.0 of flannel binary from [containernetworking/plugins](https://github.com/containernetworking/plugins)

--- a/backend/extension/extension_network.go
+++ b/backend/extension/extension_network.go
@@ -71,6 +71,22 @@ func (n *network) Run(ctx context.Context) {
 	}
 }
 
+func leaseToEnv(lease subnet.Lease) []string {
+	env := []string{}
+	if lease.EnableIPv4 {
+		env = append(env,
+			fmt.Sprintf("SUBNET=%s", lease.Subnet),
+			fmt.Sprintf("PUBLIC_IP=%s", lease.Attrs.PublicIP))
+	}
+	if lease.EnableIPv6 {
+		env = append(env,
+			fmt.Sprintf("IPV6_SUBNET=%s", lease.IPv6Subnet),
+			fmt.Sprintf("PUBLIC_IPV6=%s", lease.Attrs.PublicIPv6))
+	}
+
+	return env
+}
+
 func (n *network) handleSubnetEvents(batch []subnet.Event) {
 	for _, evt := range batch {
 		switch evt.Type {
@@ -92,9 +108,7 @@ func (n *network) handleSubnetEvents(batch []subnet.Event) {
 					}
 				}
 
-				cmd_output, err := runCmd([]string{
-					fmt.Sprintf("SUBNET=%s", evt.Lease.Subnet),
-					fmt.Sprintf("PUBLIC_IP=%s", evt.Lease.Attrs.PublicIP)},
+				cmd_output, err := runCmd(leaseToEnv(evt.Lease),
 					backendData,
 					"sh", "-c", n.subnetAddCommand)
 
@@ -122,9 +136,7 @@ func (n *network) handleSubnetEvents(batch []subnet.Event) {
 						continue
 					}
 				}
-				cmd_output, err := runCmd([]string{
-					fmt.Sprintf("SUBNET=%s", evt.Lease.Subnet),
-					fmt.Sprintf("PUBLIC_IP=%s", evt.Lease.Attrs.PublicIP)},
+				cmd_output, err := runCmd(leaseToEnv(evt.Lease),
 					backendData,
 					"sh", "-c", n.subnetRemoveCommand)
 

--- a/dist/extension-wireguard
+++ b/dist/extension-wireguard
@@ -3,9 +3,9 @@
   "Backend": {
     "Type": "extension",
     "PreStartupCommand": "wg genkey | tee privatekey | wg pubkey",
-    "PostStartupCommand": "export SUBNET_IP=`echo $SUBNET | cut -d'/' -f 1`; ip link del flannel-wg 2>/dev/null; ip link add flannel-wg type wireguard && wg set flannel-wg listen-port 51820 private-key privatekey && ip addr add $SUBNET_IP/32 dev flannel-wg && ip link set flannel-wg up && ip route add $NETWORK dev flannel-wg",
+    "PostStartupCommand": "export SUBNET_IP=$(echo $SUBNET | cut -d'/' -f 1); export SUBNET_IPV6=$(echo $IPV6_SUBNET | cut -d'/' -f 1);  ip link del flannel-wg 2>/dev/null; ip link add flannel-wg type wireguard && wg set flannel-wg listen-port 51820 private-key privatekey && (test -z ${SUBNET_IP} || ip addr add $SUBNET_IP/32 dev flannel-wg) && (test -z $SUBNET_IPV6 || ip addr add $SUBNET_IPV6/128 dev flannel-wg) && ip link set flannel-wg up && (test -z ${NETWORK} || ip route add $NETWORK dev flannel-wg) && (test -z ${IPV6_NETWORK} || ip route add $IPV6_NETWORK dev flannel-wg)",
     "ShutdownCommand": "ip link del flannel-wg",
-    "SubnetAddCommand": "read PUBLICKEY; wg set flannel-wg peer $PUBLICKEY endpoint $PUBLIC_IP:51820 allowed-ips $SUBNET",
+    "SubnetAddCommand": "read PUBLICKEY; export IPS=$(echo ${SUBNET},${IPV6_SUBNET} | sed -e 's/^,//' -e 's/,$//'); wg set flannel-wg peer $PUBLICKEY endpoint $PUBLIC_IP:51820 allowed-ips $IPS",
     "SubnetRemoveCommand": "read PUBLICKEY; wg set flannel-wg peer $PUBLICKEY remove"
   }
 }

--- a/pkg/ip/ip6net.go
+++ b/pkg/ip/ip6net.go
@@ -193,6 +193,11 @@ func (n IP6Net) Empty() bool {
 	return n.IP == (*IP6)(big.NewInt(0)) && n.PrefixLen == uint(0)
 }
 
+func (n IP6Net) UniqueLocalAddress() bool {
+	// fc00::/7 is the Unique Local address range
+	return (*big.Int)(n.IP).Bytes()[0]&0xfc == 0xfc
+}
+
 // MarshalJSON: json.Marshaler impl
 func (n IP6Net) MarshalJSON() ([]byte, error) {
 	return []byte(fmt.Sprintf(`"%s"`, n)), nil

--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -285,8 +285,8 @@ func (ksm *kubeSubnetManager) AcquireLease(ctx context.Context, attrs *subnet.Le
 				(n.Annotations[ksm.annotations.BackendPublicIPv6Overwrite] != "" && n.Annotations[ksm.annotations.BackendPublicIPv6Overwrite] != attrs.PublicIPv6.String()))) {
 		n.Annotations[ksm.annotations.BackendType] = attrs.BackendType
 
-		//TODO -i only vxlan and host-gw backends support dual stack now.
-		if (attrs.BackendType == "vxlan" && string(bd) != "null") || attrs.BackendType != "vxlan" {
+		//TODO -i only vxlan, extension, and host-gw backends support dual stack now.
+		if (attrs.BackendType == "vxlan" && string(bd) != "null") || attrs.BackendType != "vxlan" || attrs.BackendType != "extension" {
 			n.Annotations[ksm.annotations.BackendData] = string(bd)
 			if n.Annotations[ksm.annotations.BackendPublicIPOverwrite] != "" {
 				if n.Annotations[ksm.annotations.BackendPublicIP] != n.Annotations[ksm.annotations.BackendPublicIPOverwrite] {
@@ -300,7 +300,7 @@ func (ksm *kubeSubnetManager) AcquireLease(ctx context.Context, attrs *subnet.Le
 			}
 		}
 
-		if (attrs.BackendType == "vxlan" && string(v6Bd) != "null") || (attrs.BackendType == "host-gw" && attrs.PublicIPv6 != nil) {
+		if (attrs.BackendType == "vxlan" && string(v6Bd) != "null") || ((attrs.BackendType == "host-gw" || attrs.BackendType == "extension") && attrs.PublicIPv6 != nil) {
 			n.Annotations[ksm.annotations.BackendV6Data] = string(v6Bd)
 			if n.Annotations[ksm.annotations.BackendPublicIPv6Overwrite] != "" {
 				if n.Annotations[ksm.annotations.BackendPublicIPv6] != n.Annotations[ksm.annotations.BackendPublicIPv6Overwrite] {
@@ -357,8 +357,8 @@ func (ksm *kubeSubnetManager) AcquireLease(ctx context.Context, attrs *subnet.Le
 		lease.EnableIPv6 = true
 		lease.IPv6Subnet = ip.FromIP6Net(ipv6Cidr)
 	}
-	//TODO - only vxlan and host-gw backends support dual stack now.
-	if attrs.BackendType != "vxlan" && attrs.BackendType != "host-gw" {
+	//TODO - only extension, vxlan and host-gw backends support dual stack now.
+	if attrs.BackendType != "vxlan" && attrs.BackendType != "host-gw" && attrs.BackendType != "extension" {
 		lease.EnableIPv6 = false
 	}
 	return lease, nil

--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -350,14 +350,15 @@ func (ksm *kubeSubnetManager) AcquireLease(ctx context.Context, attrs *subnet.Le
 		Expiration: time.Now().Add(24 * time.Hour),
 	}
 	if cidr != nil {
+		lease.EnableIPv4 = true
 		lease.Subnet = ip.FromIPNet(cidr)
 	}
 	if ipv6Cidr != nil {
+		lease.EnableIPv6 = true
 		lease.IPv6Subnet = ip.FromIP6Net(ipv6Cidr)
 	}
 	//TODO - only vxlan and host-gw backends support dual stack now.
 	if attrs.BackendType != "vxlan" && attrs.BackendType != "host-gw" {
-		lease.EnableIPv4 = true
 		lease.EnableIPv6 = false
 	}
 	return lease, nil


### PR DESCRIPTION
## Description

This adds dual-stack support to the extension backend; Mostly for use with wireguard. 

Tested to succeed with the existing wireguard functional tests (after uncommenting them) as well as with integration into k3s: https://github.com/sjoerdsimons/k3s/tree/flannel-wireguard-dualstack