### PR TITLE
ip: Add helpers to determine if an IP address is private

### DIFF
--- a/pkg/ip/ip6net.go
+++ b/pkg/ip/ip6net.go
@@ -110,6 +110,12 @@ func (ip6 *IP6) UnmarshalJSON(j []byte) error {
 	}
 }
 
+// IsPrivate reports whether ip is a private address, according to
+// RFC 4193 (IPv6 addresses).
+func (ip6 *IP6) IsPrivate() bool {
+	return (*big.Int)(ip6).Bytes()[0]&0xfe == 0xfc
+}
+
 // similar to net.IPNet but has uint based representation
 type IP6Net struct {
 	IP        *IP6

--- a/pkg/ip/ip6net_test.go
+++ b/pkg/ip/ip6net_test.go
@@ -64,6 +64,27 @@ func TestIP6(t *testing.T) {
 	} else if string(j) != `"fc00::1"` {
 		t.Error("Marshal of IP6 failed with unexpected value: ", j)
 	}
+
+	addresses := []*struct {
+		ip      string
+		private bool
+	}{
+		{"fc00::1", true},
+		{"fcff::1", true},
+		{"fd00::1", true},
+		{"fdff::1", true},
+
+		{"2001::", false},
+		{"fe00::", false},
+	}
+
+	for _, address := range addresses {
+		ip := mkIP6(address.ip)
+		is_private := ip.IsPrivate()
+		if is_private != address.private {
+			t.Errorf("%v misdetected expected private=%v got private=%v", address.ip, address.private, is_private)
+		}
+	}
 }
 
 func TestIP6Net(t *testing.T) {

--- a/pkg/ip/ipnet.go
+++ b/pkg/ip/ipnet.go
@@ -99,6 +99,14 @@ func (ip *IP4) UnmarshalJSON(j []byte) error {
 	}
 }
 
+// IsPrivate reports whether ip is a private address, according to
+// RFC 1918 (IPv4 addresses)
+func (ip IP4) IsPrivate() bool {
+	a, b, _, _ := ip.Octets()
+
+	return a == 10 || (a == 172 && b&0xf0 == 16) || (a == 192 && b == 168)
+}
+
 // similar to net.IPNet but has uint based representation
 type IP4Net struct {
 	IP        IP4

--- a/pkg/ip/ipnet_test.go
+++ b/pkg/ip/ipnet_test.go
@@ -72,6 +72,29 @@ func TestIP4(t *testing.T) {
 	} else if string(j) != `"1.2.3.4"` {
 		t.Error("Marshal of IP4 failed with unexpected value: ", j)
 	}
+
+	addresses := []*struct {
+		ip      string
+		private bool
+	}{
+		{"192.168.0.1", true},
+		{"172.16.0.1", true},
+		{"172.31.0.1", true},
+		{"10.1.2.3", true},
+
+		{"8.8.8.8", false},
+		{"172.32.0.1", false},
+		{"192.167.0.1", false},
+		{"192.169.0.1", false},
+	}
+
+	for _, address := range addresses {
+		ip := mkIP4(address.ip)
+		is_private := ip.IsPrivate()
+		if is_private != address.private {
+			t.Errorf("%v misdetected expected private: %v got private: %v", address.ip, address.private, is_private)
+		}
+	}
 }
 
 func TestIP4Net(t *testing.T) {


### PR DESCRIPTION
Add IsPrivate methods to IP4 and IP6 to determine if a ip address is in
the private range. similar to IsPrivate of net.IP in newer golang
versions.

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>

## Description

Add some helpers for determining of address are in a private range or not; useful for determining if masquarading should be enabled.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
```release-note
None required
```
