### PR TITLE
Split ipv4 and ipv6 masquarading options

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -61,6 +61,7 @@ The following configuration illustrates the use of most options with `udp` backe
 --net-config-path=/etc/kube-flannel/net-conf.json: path to the network configuration file to use
 --subnet-lease-renew-margin=60: subnet lease renewal margin, in minutes.
 --ip-masq=false: setup IP masquerade for traffic destined for outside the flannel network. Flannel assumes that the default policy is ACCEPT in the NAT POSTROUTING chain.
+--ipv6-masq=false: setup IPv6 masquerade for traffic destined for outside the flannel network. Flannel assumes that the default policy is ACCEPT in the NAT POSTROUTING chain.
 -v=0: log level for V logs. Set to 1 to see messages related to data path.
 --healthz-ip="0.0.0.0": The IP address for healthz server to listen (default "0.0.0.0")
 --healthz-port=0: The port for healthz server to listen(0 to disable)


### PR DESCRIPTION
## Description

Masquarading policies for ipv4 and ipv6 are ortogonal e.g. a cluster
could have a private range of ipv4 addresses but a public ipv6 range. In
which case you'd probably want to masquarade ipv4 but not ipv6.

## Release Note

```release-note
* the --ipv6-masq option has been added to enable ipv6 masquarading; --ip-masq now only enables ipv4 masquarading
```
