### PR TITLE
rebase add mips64le support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -4,7 +4,7 @@ on: [push, pull_request]
 
 env:
   GO_VERSION: "1.15.15"
-  LINUX_ARCHES: "amd64 arm arm64 s390x ppc64le"
+  LINUX_ARCHES: "amd64 arm arm64 s390x ppc64le mips64le"
 
 jobs:
   build-images:
@@ -70,4 +70,11 @@ jobs:
         with:
           context: .
           file: Dockerfile.ppc64le
+          push: false
+
+      - name: Build Docker image for mips64le
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.mips64le
           push: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,7 @@ on:
 
 env:
   GO_VERSION: "1.15.15"
-  LINUX_ARCHES: "amd64 arm arm64 s390x ppc64le"
+  LINUX_ARCHES: "amd64 arm arm64 s390x ppc64le mips64le"
   REPOSITORY: flannelcni/flannel
 
 jobs:
@@ -100,6 +100,15 @@ jobs:
           file: Dockerfile.ppc64le
           push: true
           tags: ${{ steps.meta.outputs.tags }}-ppc64le
+        
+      - name: Build and push Docker image for mips64le
+        if: github.repository_owner == 'flannel-io'
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: Dockerfile.mips64le
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}-mips64le
 
   build-and-push-multi-arch-image:
     needs: [build-and-push-images]
@@ -156,12 +165,14 @@ jobs:
           docker pull ${{ steps.meta.outputs.tags }}-arm
           docker pull ${{ steps.meta.outputs.tags }}-ppc64le
           docker pull ${{ steps.meta.outputs.tags }}-s390x
-          docker manifest create ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-amd64 ${{ steps.meta.outputs.tags }}-arm64 ${{ steps.meta.outputs.tags }}-arm ${{ steps.meta.outputs.tags }}-ppc64le ${{ steps.meta.outputs.tags }}-s390x
+          docker pull ${{ steps.meta.outputs.tags }}-mips64le
+          docker manifest create ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-amd64 ${{ steps.meta.outputs.tags }}-arm64 ${{ steps.meta.outputs.tags }}-arm ${{ steps.meta.outputs.tags }}-ppc64le ${{ steps.meta.outputs.tags }}-s390x ${{ steps.meta.outputs.tags }}-mips64le
           docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-amd64 --arch amd64
           docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-arm64 --arch arm64
           docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-arm --arch arm
           docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-ppc64le --arch ppc64le
           docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-s390x --arch s390x
+          docker manifest annotate ${{ steps.meta.outputs.tags }} ${{ steps.meta.outputs.tags }}-mips64le --arch mips64le
           docker manifest push ${{ steps.meta.outputs.tags }}
           docker pull ${{ steps.meta.outputs.tags }}
           docker tag ${{ steps.meta.outputs.tags }} ${{ env.REPOSITORY }}:latest

--- a/Dockerfile.mips64le
+++ b/Dockerfile.mips64le
@@ -1,0 +1,13 @@
+FROM loongnix/alpine:3.11
+
+LABEL maintainer="Tom Denham <tom@tigera.io>"
+
+ENV FLANNEL_ARCH=mips64le
+
+ADD dist/qemu-$FLANNEL_ARCH-static /usr/bin/qemu-$FLANNEL_ARCH-static
+RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan && update-ca-certificates
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
+COPY dist/mk-docker-opts.sh /opt/bin/
+
+ENTRYPOINT ["/opt/bin/flanneld"]

--- a/Dockerfile.mips64le
+++ b/Dockerfile.mips64le
@@ -1,13 +1,13 @@
 FROM loongnix/alpine:3.11
 
-LABEL maintainer="Tom Denham <tom@tigera.io>"
-
 ENV FLANNEL_ARCH=mips64le
 
 ADD dist/qemu-$FLANNEL_ARCH-static /usr/bin/qemu-$FLANNEL_ARCH-static
 RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan && update-ca-certificates
-RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
+COPY dist/iptables-wrapper-installer.sh /
+RUN /iptables-wrapper-installer.sh --no-sanity-check
 
 ENTRYPOINT ["/opt/bin/flanneld"]

--- a/Dockerfile.mips64le
+++ b/Dockerfile.mips64le
@@ -1,10 +1,13 @@
-FROM loongnix/alpine:3.11
+FROM mips64le/debian:stable-20211220-slim
 
 ENV FLANNEL_ARCH=mips64le
 
 ADD dist/qemu-$FLANNEL_ARCH-static /usr/bin/qemu-$FLANNEL_ARCH-static
-RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan && update-ca-certificates
-RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
+# RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan && update-ca-certificates
+# RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
+RUN apt update && \
+    apt-get install -y iproute2 net-tools ca-certificates iptables strongswan wireguard-tools && \
+    update-ca-certificates
 COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 COPY dist/iptables-wrapper-installer.sh /

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ dist/flanneld.exe: $(shell find . -type f  -name '*.go')
 
 # This will build flannel natively using golang image
 dist/flanneld-$(ARCH): dist/qemu-$(ARCH)-static
-	# valid values for ARCH are [amd64 arm arm64 ppc64le s390x]
+	# valid values for ARCH are [amd64 arm arm64 ppc64le s390x mips64le]
 	docker run -e CGO_ENABLED=$(CGO_ENABLED) -e GOARCH=$(ARCH) -e GOCACHE=/go \
 		-u $(shell id -u):$(shell id -g) \
 		-v $(CURDIR)/dist/qemu-$(ARCH)-static:/usr/bin/qemu-$(ARCH)-static \
@@ -128,7 +128,7 @@ dist/flanneld-e2e-$(TAG)-$(ARCH).docker:
 ifneq ($(ARCH),amd64)
 	$(MAKE) dist/qemu-$(ARCH)-static
 endif
-	# valid values for ARCH are [amd64 arm arm64 ppc64le s390x]
+	# valid values for ARCH are [amd64 arm arm64 ppc64le s390x mips64le]
 	docker run -e GOARM=$(GOARM) -e GOCACHE=/go \
 		-u $(shell id -u):$(shell id -g) \
 		-v $(CURDIR):/go/src/github.com/flannel-io/flannel:ro \
@@ -141,12 +141,13 @@ endif
 
 # Make a release after creating a tag
 # To build cross platform Docker images, the qemu-static binaries are needed. On ubuntu "apt-get install  qemu-user-static"
-release: tar.gz dist/qemu-s390x-static dist/qemu-ppc64le-static dist/qemu-arm64-static dist/qemu-arm-static #release-tests
+release: tar.gz dist/qemu-s390x-static dist/qemu-ppc64le-static dist/qemu-arm64-static dist/qemu-arm-static dist/qemu-mips64le-static #release-tests
 	ARCH=amd64 make dist/flanneld-$(TAG)-amd64.docker
 	ARCH=arm make dist/flanneld-$(TAG)-arm.docker
 	ARCH=arm64 make dist/flanneld-$(TAG)-arm64.docker
 	ARCH=ppc64le make dist/flanneld-$(TAG)-ppc64le.docker
 	ARCH=s390x make dist/flanneld-$(TAG)-s390x.docker
+	ARCH=mips64le make dist/flanneld-$(TAG)-mips64le.docker
 	@echo "Everything should be built for $(TAG)"
 	@echo "Add all flanneld-* and *.tar.gz files from dist/ to the Github release"
 	@echo "Use make docker-push-all to push the images to a registry"
@@ -156,11 +157,13 @@ dist/qemu-%-static:
 		wget -O dist/qemu-amd64-static https://github.com/multiarch/qemu-user-static/releases/download/$(QEMU_VERSION)/qemu-x86_64-static; \
 	elif [ "$(@F)" = "qemu-arm64-static" ]; then \
 		wget -O dist/qemu-arm64-static https://github.com/multiarch/qemu-user-static/releases/download/$(QEMU_VERSION)/qemu-aarch64-static; \
+	elif [ "$(@F)" = "qemu-mips64le-static" ]; then \
+		wget -O dist/qemu-mips64le-static https://github.com/multiarch/qemu-user-static/releases/download/$(QEMU_VERSION)/qemu-mips64el-static; \
 	else \
 		wget -O dist/$(@F) https://github.com/multiarch/qemu-user-static/releases/download/$(QEMU_VERSION)/$(@F); \
 	fi 
 
-## Build a .tar.gz for the amd64 ppc64le arm arm64 flanneld binary
+## Build a .tar.gz for the amd64 ppc64le arm arm64 mips64le flanneld binary
 tar.gz:
 	ARCH=amd64 make dist/flanneld-amd64
 	tar --transform='flags=r;s|-amd64||' -zcvf dist/flannel-$(TAG)-linux-amd64.tar.gz -C dist flanneld-amd64 mk-docker-opts.sh ../README.md
@@ -180,6 +183,9 @@ tar.gz:
 	ARCH=s390x make dist/flanneld-s390x
 	tar --transform='flags=r;s|-s390x||' -zcvf dist/flannel-$(TAG)-linux-s390x.tar.gz -C dist flanneld-s390x mk-docker-opts.sh ../README.md
 	tar -tvf dist/flannel-$(TAG)-linux-s390x.tar.gz
+	ARCH=mips64le make dist/flanneld-mips64le
+	tar --transform='flags=r;s|-mips64le||' -zcvf dist/flannel-$(TAG)-linux-mips64le.tar.gz -C dist flanneld-mips64le mk-docker-opts.sh ../README.md
+	tar -tvf dist/flannel-$(TAG)-linux-mips64le.tar.gz
 
 release-tests: release-etcd-tests release-k8s-tests
 
@@ -217,6 +223,7 @@ docker-push-all:
 	ARCH=arm64 make docker-push docker-manifest-amend
 	ARCH=ppc64le make docker-push docker-manifest-amend
 	ARCH=s390x make docker-push docker-manifest-amend
+	ARCH=mips64le make docker-push docker-manifest-amend
 	make docker-manifest-push
 
 flannel-git:
@@ -225,6 +232,7 @@ flannel-git:
 	ARCH=arm64 REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-arm64.docker docker-push docker-manifest-amend
 	ARCH=ppc64le REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-ppc64le.docker docker-push docker-manifest-amend
 	ARCH=s390x REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-s390x.docker docker-push docker-manifest-amend
+	ARCH=mips64le REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-mips64le.docker docker-push docker-manifest-amend
 	REGISTRY=quay.io/coreos/flannel-git make docker-manifest-push
 
 install:


### PR DESCRIPTION
The ARCH is mips64le because mipsel is a joke created by Debian. (Because little endian reverse the byte order, they also reversed the letter LE to form el.)

The change version can run successfully by cross-compile. But still need to test because I don't have mips64el environment.