### PR TITLE
feat: add support for --iface-regex match interface with multi IP addresses

### DIFF
--- a/main.go
+++ b/main.go
@@ -105,13 +105,6 @@ var (
 	flannelFlags   = flag.NewFlagSet("flannel", flag.ExitOnError)
 )
 
-const (
-	ipv4Stack int = iota
-	ipv6Stack
-	dualStack
-	noneStack
-)
-
 func init() {
 	flannelFlags.StringVar(&opts.etcdEndpoints, "etcd-endpoints", "http://127.0.0.1:4001,http://127.0.0.1:2379", "a comma-delimited list of etcd endpoints")
 	flannelFlags.StringVar(&opts.etcdPrefix, "etcd-prefix", "/coreos.com/network", "etcd prefix")
@@ -145,10 +138,9 @@ func init() {
 	// can flow into journald (if running under systemd)
 	err := flag.Set("logtostderr", "true")
 	if err != nil {
-                log.Error("Can't set the logtostderr flag", err)
-                os.Exit(1)
+		log.Error("Can't set the logtostderr flag", err)
+		os.Exit(1)
 	}
-
 
 	// Only copy the non file logging options from klog
 	copyFlag("v")
@@ -160,11 +152,10 @@ func init() {
 
 	// now parse command line args
 	err = flannelFlags.Parse(os.Args[1:])
-        if err != nil {
-                log.Error("Can't parse flannel flags", err)
-                os.Exit(1)
-        }
-
+	if err != nil {
+		log.Error("Can't parse flannel flags", err)
+		os.Exit(1)
+	}
 }
 
 func copyFlag(name string) {

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 	"sync"
@@ -33,6 +32,7 @@ import (
 	"github.com/coreos/pkg/flagutil"
 	"github.com/flannel-io/flannel/network"
 	"github.com/flannel-io/flannel/pkg/ip"
+	"github.com/flannel-io/flannel/pkg/ipmatch"
 	"github.com/flannel-io/flannel/subnet"
 	"github.com/flannel-io/flannel/subnet/etcdv2"
 	"github.com/flannel-io/flannel/subnet/kube"
@@ -177,17 +177,6 @@ func usage() {
 	os.Exit(0)
 }
 
-func getIPFamily(autoDetectIPv4, autoDetectIPv6 bool) (int, error) {
-	if autoDetectIPv4 && !autoDetectIPv6 {
-		return ipv4Stack, nil
-	} else if !autoDetectIPv4 && autoDetectIPv6 {
-		return ipv6Stack, nil
-	} else if autoDetectIPv4 && autoDetectIPv6 {
-		return dualStack, nil
-	}
-	return noneStack, errors.New("none defined stack")
-}
-
 func newSubnetManager(ctx context.Context) (subnet.Manager, error) {
 	if opts.kubeSubnetMgr {
 		return kube.NewSubnetManager(ctx, opts.kubeApiUrl, opts.kubeConfigFile, opts.kubeAnnotationPrefix, opts.netConfPath, opts.setNodeNetworkUnavailable)
@@ -269,16 +258,21 @@ func main() {
 	}
 
 	// Get ip family stack
-	ipStack, stackErr := getIPFamily(config.EnableIPv4, config.EnableIPv6)
+	ipStack, stackErr := ipmatch.GetIPFamily(config.EnableIPv4, config.EnableIPv6)
 	if stackErr != nil {
 		log.Error(stackErr.Error())
 		os.Exit(1)
 	}
+
 	// Work out which interface to use
 	var extIface *backend.ExternalInterface
+	optsPublicIP := ipmatch.PublicIPOpts{
+		PublicIP:   opts.publicIP,
+		PublicIPv6: opts.publicIPv6,
+	}
 	// Check the default interface only if no interfaces are specified
 	if len(opts.iface) == 0 && len(opts.ifaceRegex) == 0 {
-		extIface, err = LookupExtIface(opts.publicIP, "", ipStack)
+		extIface, err = ipmatch.LookupExtIface(opts.publicIP, "", ipStack, optsPublicIP)
 		if err != nil {
 			log.Error("Failed to find any valid interface to use: ", err)
 			os.Exit(1)
@@ -286,7 +280,7 @@ func main() {
 	} else {
 		// Check explicitly specified interfaces
 		for _, iface := range opts.iface {
-			extIface, err = LookupExtIface(iface, "", ipStack)
+			extIface, err = ipmatch.LookupExtIface(iface, "", ipStack, optsPublicIP)
 			if err != nil {
 				log.Infof("Could not find valid interface matching %s: %s", iface, err)
 			}
@@ -299,7 +293,7 @@ func main() {
 		// Check interfaces that match any specified regexes
 		if extIface == nil {
 			for _, ifaceRegex := range opts.ifaceRegex {
-				extIface, err = LookupExtIface("", ifaceRegex, ipStack)
+				extIface, err = ipmatch.LookupExtIface("", ifaceRegex, ipStack, optsPublicIP)
 				if err != nil {
 					log.Infof("Could not find valid interface matching %s: %s", ifaceRegex, err)
 				}
@@ -524,237 +518,6 @@ func MonitorLease(ctx context.Context, sm subnet.Manager, bn backend.Network, wg
 	}
 }
 
-func LookupExtIface(ifname string, ifregexS string, ipStack int) (*backend.ExternalInterface, error) {
-	var iface *net.Interface
-	var ifaceAddr net.IP
-	var ifaceV6Addr net.IP
-	var err error
-	var ifregex *regexp.Regexp
-
-	if ifregexS != "" {
-		ifregex, err = regexp.Compile(ifregexS)
-		if err != nil {
-			return nil, fmt.Errorf("could not compile the IP address regex '%s': %w", ifregexS, err)
-		}
-	}
-
-	// Check ip family stack
-	if ipStack == noneStack {
-		return nil, fmt.Errorf("none matched ip stack")
-	}
-
-	if len(ifname) > 0 {
-		if ifaceAddr = net.ParseIP(ifname); ifaceAddr != nil {
-			log.Infof("Searching for interface using %s", ifaceAddr)
-			switch ipStack {
-			case ipv4Stack:
-				iface, err = ip.GetInterfaceByIP(ifaceAddr)
-				if err != nil {
-					return nil, fmt.Errorf("error looking up interface %s: %s", ifname, err)
-				}
-			case ipv6Stack:
-				iface, err = ip.GetInterfaceByIP6(ifaceAddr)
-				if err != nil {
-					return nil, fmt.Errorf("error looking up v6 interface %s: %s", ifname, err)
-				}
-			case dualStack:
-				iface, err = ip.GetInterfaceByIP(ifaceAddr)
-				if err != nil {
-					return nil, fmt.Errorf("error looking up interface %s: %s", ifname, err)
-				}
-				v6Iface, err := ip.GetInterfaceByIP6(ifaceAddr)
-				if err != nil {
-					return nil, fmt.Errorf("error looking up v6 interface %s: %s", ifname, err)
-				}
-				if iface.Name != v6Iface.Name {
-					return nil, fmt.Errorf("v6 interface %s must be the same with v4 interface %s", v6Iface.Name, iface.Name)
-				}
-			}
-		} else {
-			iface, err = net.InterfaceByName(ifname)
-			if err != nil {
-				return nil, fmt.Errorf("error looking up interface %s: %s", ifname, err)
-			}
-		}
-	} else if ifregex != nil {
-		// Use the regex if specified and the iface option for matching a specific ip or name is not used
-		ifaces, err := net.Interfaces()
-		if err != nil {
-			return nil, fmt.Errorf("error listing all interfaces: %s", err)
-		}
-
-	ifaceLoop:
-		// Check IP
-		for _, ifaceToMatch := range ifaces {
-			switch ipStack {
-			case ipv4Stack:
-				ifaceIP, err := ip.GetInterfaceIP4Addr(&ifaceToMatch)
-				if err != nil {
-					// Skip if there is no IPv4 address
-					continue
-				}
-
-				if ifregex.MatchString(ifaceIP.String()) {
-					ifaceAddr = ifaceIP
-					iface = &ifaceToMatch
-					break ifaceLoop
-				}
-			case ipv6Stack:
-				ifaceIP, err := ip.GetInterfaceIP6Addr(&ifaceToMatch)
-				if err != nil {
-					// Skip if there is no IPv6 address
-					continue
-				}
-
-				if ifregex.MatchString(ifaceIP.String()) {
-					ifaceV6Addr = ifaceIP
-					iface = &ifaceToMatch
-					break ifaceLoop
-				}
-			case dualStack:
-				ifaceIP, err := ip.GetInterfaceIP4Addr(&ifaceToMatch)
-				if err != nil {
-					// Skip if there is no IPv4 address
-					continue
-				}
-
-				ifaceV6IP, err := ip.GetInterfaceIP6Addr(&ifaceToMatch)
-				if err != nil {
-					// Skip if there is no IPv6 address
-					continue
-				}
-
-				if ifregex.MatchString(ifaceIP.String()) && ifregex.MatchString(ifaceV6IP.String()) {
-					ifaceAddr = ifaceIP
-					ifaceV6Addr = ifaceV6IP
-					iface = &ifaceToMatch
-					break ifaceLoop
-				}
-			}
-		}
-
-		// Check Name
-		if iface == nil && (ifaceAddr == nil || ifaceV6Addr == nil) {
-			for _, ifaceToMatch := range ifaces {
-				if ifregex.MatchString(ifaceToMatch.Name) {
-					iface = &ifaceToMatch
-					break
-				}
-			}
-		}
-
-		// Check that nothing was matched
-		if iface == nil {
-			var availableFaces []string
-			for _, f := range ifaces {
-				var ipaddr net.IP
-				switch ipStack {
-				case ipv4Stack, dualStack:
-					ipaddr, _ = ip.GetInterfaceIP4Addr(&f) // We can safely ignore errors. We just won't log any ip
-				case ipv6Stack:
-					ipaddr, _ = ip.GetInterfaceIP6Addr(&f) // We can safely ignore errors. We just won't log any ip
-				}
-				availableFaces = append(availableFaces, fmt.Sprintf("%s:%s", f.Name, ipaddr))
-			}
-
-			return nil, fmt.Errorf("Could not match pattern %s to any of the available network interfaces (%s)", ifregexS, strings.Join(availableFaces, ", "))
-		}
-	} else {
-		log.Info("Determining IP address of default interface")
-		switch ipStack {
-		case ipv4Stack:
-			if iface, err = ip.GetDefaultGatewayInterface(); err != nil {
-				return nil, fmt.Errorf("failed to get default interface: %w", err)
-			}
-		case ipv6Stack:
-			if iface, err = ip.GetDefaultV6GatewayInterface(); err != nil {
-				return nil, fmt.Errorf("failed to get default v6 interface: %w", err)
-			}
-		case dualStack:
-			if iface, err = ip.GetDefaultGatewayInterface(); err != nil {
-				return nil, fmt.Errorf("failed to get default interface: %w", err)
-			}
-			v6Iface, err := ip.GetDefaultV6GatewayInterface()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get default v6 interface: %w", err)
-			}
-			if iface.Name != v6Iface.Name {
-				return nil, fmt.Errorf("v6 default route interface %s "+
-					"must be the same with v4 default route interface %s", v6Iface.Name, iface.Name)
-			}
-		}
-	}
-
-	if ipStack == ipv4Stack && ifaceAddr == nil {
-		ifaceAddr, err = ip.GetInterfaceIP4Addr(iface)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find IPv4 address for interface %s", iface.Name)
-		}
-	} else if ipStack == ipv6Stack && ifaceV6Addr == nil {
-		ifaceV6Addr, err = ip.GetInterfaceIP6Addr(iface)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find IPv6 address for interface %s", iface.Name)
-		}
-	} else if ipStack == dualStack && ifaceAddr == nil && ifaceV6Addr == nil {
-		ifaceAddr, err = ip.GetInterfaceIP4Addr(iface)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find IPv4 address for interface %s", iface.Name)
-		}
-		ifaceV6Addr, err = ip.GetInterfaceIP6Addr(iface)
-		if err != nil {
-			return nil, fmt.Errorf("failed to find IPv6 address for interface %s", iface.Name)
-		}
-	}
-
-	if ifaceAddr != nil {
-		log.Infof("Using interface with name %s and address %s", iface.Name, ifaceAddr)
-	}
-	if ifaceV6Addr != nil {
-		log.Infof("Using interface with name %s and v6 address %s", iface.Name, ifaceV6Addr)
-	}
-
-	if iface.MTU == 0 {
-		return nil, fmt.Errorf("failed to determine MTU for %s interface", ifaceAddr)
-	}
-
-	var extAddr net.IP
-	var extV6Addr net.IP
-
-	if len(opts.publicIP) > 0 {
-		extAddr = net.ParseIP(opts.publicIP)
-		if extAddr == nil {
-			return nil, fmt.Errorf("invalid public IP address: %s", opts.publicIP)
-		}
-		log.Infof("Using %s as external address", extAddr)
-	}
-
-	if extAddr == nil && ipStack != ipv6Stack {
-		log.Infof("Defaulting external address to interface address (%s)", ifaceAddr)
-		extAddr = ifaceAddr
-	}
-
-	if len(opts.publicIPv6) > 0 {
-		extV6Addr = net.ParseIP(opts.publicIPv6)
-		if extV6Addr == nil {
-			return nil, fmt.Errorf("invalid public IPv6 address: %s", opts.publicIPv6)
-		}
-		log.Infof("Using %s as external address", extV6Addr)
-	}
-
-	if extV6Addr == nil && ipStack != ipv4Stack {
-		log.Infof("Defaulting external v6 address to interface address (%s)", ifaceV6Addr)
-		extV6Addr = ifaceV6Addr
-	}
-
-	return &backend.ExternalInterface{
-		Iface:       iface,
-		IfaceAddr:   ifaceAddr,
-		IfaceV6Addr: ifaceV6Addr,
-		ExtAddr:     extAddr,
-		ExtV6Addr:   extV6Addr,
-	}, nil
-}
-
 func WriteSubnetFile(path string, config *subnet.Config, ipMasq bool, bn backend.Network) error {
 	dir, name := filepath.Split(path)
 	err := os.MkdirAll(dir, 0755)
@@ -793,7 +556,7 @@ func WriteSubnetFile(path string, config *subnet.Config, ipMasq bool, bn backend
 	// rename(2) the temporary file to the desired location so that it becomes
 	// atomically visible with the contents
 	return os.Rename(tempFile, path)
-	//TODO - is this safe? What if it's not on the same FS?
+	// TODO - is this safe? What if it's not on the same FS?
 }
 
 func mustRunHealthz(stopChan <-chan struct{}, wg *sync.WaitGroup) {

--- a/pkg/ip/iface_windows.go
+++ b/pkg/ip/iface_windows.go
@@ -25,8 +25,8 @@ import (
 	"github.com/flannel-io/flannel/pkg/powershell"
 )
 
-// GetInterfaceIP4Addr returns the IPv4 address for the given network interface
-func GetInterfaceIP4Addr(iface *net.Interface) ([]net.IP, error) {
+// GetInterfaceIP4Addrs returns the IPv4 address for the given network interface
+func GetInterfaceIP4Addrs(iface *net.Interface) ([]net.IP, error) {
 	addrs, err := iface.Addrs()
 	if err != nil {
 		return nil, err
@@ -152,6 +152,6 @@ func IsForwardingEnabledForInterface(iface *net.Interface) (bool, error) {
 	return powerShellJsonData.Forwarding == 1, nil
 }
 
-func GetInterfaceByIP6(ip net.IP) (*net.Interface, error)        { return nil, nil }
-func GetInterfaceIP6Addr(iface *net.Interface) ([]net.IP, error) { return nil, nil }
-func GetDefaultV6GatewayInterface() (*net.Interface, error)      { return nil, nil }
+func GetInterfaceByIP6(ip net.IP) (*net.Interface, error)         { return nil, nil }
+func GetInterfaceIP6Addrs(iface *net.Interface) ([]net.IP, error) { return nil, nil }
+func GetDefaultV6GatewayInterface() (*net.Interface, error)       { return nil, nil }

--- a/pkg/ip/iface_windows.go
+++ b/pkg/ip/iface_windows.go
@@ -26,11 +26,13 @@ import (
 )
 
 // GetInterfaceIP4Addr returns the IPv4 address for the given network interface
-func GetInterfaceIP4Addr(iface *net.Interface) (net.IP, error) {
+func GetInterfaceIP4Addr(iface *net.Interface) ([]net.IP, error) {
 	addrs, err := iface.Addrs()
 	if err != nil {
 		return nil, err
 	}
+
+	ipAddrs := make([]net.IP, 0)
 
 	for _, addr := range addrs {
 		var ip net.IP
@@ -42,8 +44,12 @@ func GetInterfaceIP4Addr(iface *net.Interface) (net.IP, error) {
 		}
 
 		if ip != nil && ip.To4() != nil {
-			return ip, nil
+			ipAddrs = append(ipAddrs, ip)
 		}
+	}
+
+	if len(ipAddrs) > 0 {
+		return ipAddrs, nil
 	}
 
 	return nil, errors.New("no IPv4 address found for given interface")
@@ -146,6 +152,6 @@ func IsForwardingEnabledForInterface(iface *net.Interface) (bool, error) {
 	return powerShellJsonData.Forwarding == 1, nil
 }
 
-func GetInterfaceByIP6(ip net.IP) (*net.Interface, error)      { return nil, nil }
-func GetInterfaceIP6Addr(iface *net.Interface) (net.IP, error) { return nil, nil }
-func GetDefaultV6GatewayInterface() (*net.Interface, error)    { return nil, nil }
+func GetInterfaceByIP6(ip net.IP) (*net.Interface, error)        { return nil, nil }
+func GetInterfaceIP6Addr(iface *net.Interface) ([]net.IP, error) { return nil, nil }
+func GetDefaultV6GatewayInterface() (*net.Interface, error)      { return nil, nil }

--- a/pkg/ip/iface_windows_test.go
+++ b/pkg/ip/iface_windows_test.go
@@ -27,7 +27,7 @@ func TestGetInterfaceIP4Addr(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = GetInterfaceIP4Addr(iface)
+	_, err = GetInterfaceIP4Addrs(iface)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +46,7 @@ func TestGetInterfaceByIP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	defaultIpv4Addr, err := GetInterfaceIP4Addr(defaultIface)
+	defaultIpv4Addr, err := GetInterfaceIP4Addrs(defaultIface)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/ipmatch/match.go
+++ b/pkg/ipmatch/match.go
@@ -94,6 +94,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 		}
 
 		// Check IP
+	ifaceLoop:
 		for _, ifaceToMatch := range ifaces {
 			switch ipStack {
 			case IPv4Stack:
@@ -105,7 +106,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 				if matched := matchIP(ifregex, ifaceIPs); matched != nil {
 					ifaceAddr = matched
 					iface = &ifaceToMatch
-					break
+					break ifaceLoop
 				}
 			case IPv6Stack:
 				ifaceIPs, err := ip.GetInterfaceIP6Addr(&ifaceToMatch)
@@ -116,7 +117,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 				if matched := matchIP(ifregex, ifaceIPs); matched != nil {
 					ifaceV6Addr = matched
 					iface = &ifaceToMatch
-					break
+					break ifaceLoop
 				}
 			case DualStack:
 				ifaceIPs, err := ip.GetInterfaceIP4Addr(&ifaceToMatch)
@@ -139,7 +140,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 				if matched := matchIP(ifregex, ifaceV6IPs); matched != nil {
 					ifaceV6Addr = matched
 					iface = &ifaceToMatch
-					break
+					break ifaceLoop
 				}
 			}
 		}

--- a/pkg/ipmatch/match.go
+++ b/pkg/ipmatch/match.go
@@ -1,3 +1,17 @@
+// Copyright 2022 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ipmatch
 
 import (

--- a/pkg/ipmatch/match.go
+++ b/pkg/ipmatch/match.go
@@ -1,0 +1,282 @@
+package ipmatch
+
+import (
+	"errors"
+	"fmt"
+	"github.com/flannel-io/flannel/backend"
+	"github.com/flannel-io/flannel/pkg/ip"
+	log "k8s.io/klog"
+	"net"
+	"regexp"
+	"strings"
+)
+
+const (
+	IPv4Stack int = iota
+	IPv6Stack
+	DualStack
+	NoneStack
+)
+
+type PublicIPOpts struct {
+	PublicIP   string
+	PublicIPv6 string
+}
+
+func GetIPFamily(autoDetectIPv4, autoDetectIPv6 bool) (int, error) {
+	if autoDetectIPv4 && !autoDetectIPv6 {
+		return IPv4Stack, nil
+	} else if !autoDetectIPv4 && autoDetectIPv6 {
+		return IPv6Stack, nil
+	} else if autoDetectIPv4 && autoDetectIPv6 {
+		return DualStack, nil
+	}
+	return NoneStack, errors.New("none defined stack")
+}
+
+func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOpts) (*backend.ExternalInterface, error) {
+	var iface *net.Interface
+	var ifaceAddr net.IP
+	var ifaceV6Addr net.IP
+	var err error
+	var ifregex *regexp.Regexp
+
+	if ifregexS != "" {
+		ifregex, err = regexp.Compile(ifregexS)
+		if err != nil {
+			return nil, fmt.Errorf("could not compile the IP address regex '%s': %w", ifregexS, err)
+		}
+	}
+
+	// Check ip family stack
+	if ipStack == NoneStack {
+		return nil, fmt.Errorf("none matched ip stack")
+	}
+
+	if len(ifname) > 0 {
+		if ifaceAddr = net.ParseIP(ifname); ifaceAddr != nil {
+			log.Infof("Searching for interface using %s", ifaceAddr)
+			switch ipStack {
+			case IPv4Stack:
+				iface, err = ip.GetInterfaceByIP(ifaceAddr)
+				if err != nil {
+					return nil, fmt.Errorf("error looking up interface %s: %s", ifname, err)
+				}
+			case IPv6Stack:
+				iface, err = ip.GetInterfaceByIP6(ifaceAddr)
+				if err != nil {
+					return nil, fmt.Errorf("error looking up v6 interface %s: %s", ifname, err)
+				}
+			case DualStack:
+				iface, err = ip.GetInterfaceByIP(ifaceAddr)
+				if err != nil {
+					return nil, fmt.Errorf("error looking up interface %s: %s", ifname, err)
+				}
+				v6Iface, err := ip.GetInterfaceByIP6(ifaceAddr)
+				if err != nil {
+					return nil, fmt.Errorf("error looking up v6 interface %s: %s", ifname, err)
+				}
+				if iface.Name != v6Iface.Name {
+					return nil, fmt.Errorf("v6 interface %s must be the same with v4 interface %s", v6Iface.Name, iface.Name)
+				}
+			}
+		} else {
+			iface, err = net.InterfaceByName(ifname)
+			if err != nil {
+				return nil, fmt.Errorf("error looking up interface %s: %s", ifname, err)
+			}
+		}
+	} else if ifregex != nil {
+		// Use the regex if specified and the iface option for matching a specific ip or name is not used
+		ifaces, err := net.Interfaces()
+		if err != nil {
+			return nil, fmt.Errorf("error listing all interfaces: %s", err)
+		}
+
+		// Check IP
+		for _, ifaceToMatch := range ifaces {
+			switch ipStack {
+			case IPv4Stack:
+				ifaceIPs, err := ip.GetInterfaceIP4Addr(&ifaceToMatch)
+				if err != nil {
+					// Skip if there is no IPv4 address
+					continue
+				}
+				if matched := matchIP(ifregex, ifaceIPs); matched != nil {
+					ifaceAddr = matched
+					iface = &ifaceToMatch
+					break
+				}
+			case IPv6Stack:
+				ifaceIPs, err := ip.GetInterfaceIP6Addr(&ifaceToMatch)
+				if err != nil {
+					// Skip if there is no IPv6 address
+					continue
+				}
+				if matched := matchIP(ifregex, ifaceIPs); matched != nil {
+					ifaceV6Addr = matched
+					iface = &ifaceToMatch
+					break
+				}
+			case DualStack:
+				ifaceIPs, err := ip.GetInterfaceIP4Addr(&ifaceToMatch)
+				if err != nil {
+					// Skip if there is no IPv4 address
+					continue
+				}
+
+				ifaceV6IPs, err := ip.GetInterfaceIP6Addr(&ifaceToMatch)
+				if err != nil {
+					// Skip if there is no IPv6 address
+					continue
+				}
+
+				if matched := matchIP(ifregex, ifaceIPs); matched != nil {
+					ifaceAddr = matched
+				} else {
+					continue
+				}
+				if matched := matchIP(ifregex, ifaceV6IPs); matched != nil {
+					ifaceV6Addr = matched
+					iface = &ifaceToMatch
+					break
+				}
+			}
+		}
+
+		// Check Name
+		if iface == nil && (ifaceAddr == nil || ifaceV6Addr == nil) {
+			for _, ifaceToMatch := range ifaces {
+				if ifregex.MatchString(ifaceToMatch.Name) {
+					iface = &ifaceToMatch
+					break
+				}
+			}
+		}
+
+		// Check that nothing was matched
+		if iface == nil {
+			var availableFaces []string
+			for _, f := range ifaces {
+				var ipaddr []net.IP
+				switch ipStack {
+				case IPv4Stack, DualStack:
+					ipaddr, _ = ip.GetInterfaceIP4Addr(&f) // We can safely ignore errors. We just won't log any ip
+				case IPv6Stack:
+					ipaddr, _ = ip.GetInterfaceIP6Addr(&f) // We can safely ignore errors. We just won't log any ip
+				}
+				availableFaces = append(availableFaces, fmt.Sprintf("%s:%v", f.Name, ipaddr))
+			}
+
+			return nil, fmt.Errorf("Could not match pattern %s to any of the available network interfaces (%s)", ifregexS, strings.Join(availableFaces, ", "))
+		}
+	} else {
+		log.Info("Determining IP address of default interface")
+		switch ipStack {
+		case IPv4Stack:
+			if iface, err = ip.GetDefaultGatewayInterface(); err != nil {
+				return nil, fmt.Errorf("failed to get default interface: %w", err)
+			}
+		case IPv6Stack:
+			if iface, err = ip.GetDefaultV6GatewayInterface(); err != nil {
+				return nil, fmt.Errorf("failed to get default v6 interface: %w", err)
+			}
+		case DualStack:
+			if iface, err = ip.GetDefaultGatewayInterface(); err != nil {
+				return nil, fmt.Errorf("failed to get default interface: %w", err)
+			}
+			v6Iface, err := ip.GetDefaultV6GatewayInterface()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get default v6 interface: %w", err)
+			}
+			if iface.Name != v6Iface.Name {
+				return nil, fmt.Errorf("v6 default route interface %s "+
+					"must be the same with v4 default route interface %s", v6Iface.Name, iface.Name)
+			}
+		}
+	}
+
+	var ifaceAddrs []net.IP
+	var ifaceV6Addrs []net.IP
+	if ipStack == IPv4Stack && ifaceAddr == nil {
+		ifaceAddrs, err = ip.GetInterfaceIP4Addr(iface)
+		if err != nil || len(ifaceAddrs) == 0 {
+			return nil, fmt.Errorf("failed to find IPv4 address for interface %s", iface.Name)
+		}
+		ifaceAddr = ifaceAddrs[0]
+	} else if ipStack == IPv6Stack && ifaceV6Addr == nil {
+		ifaceV6Addrs, err = ip.GetInterfaceIP6Addr(iface)
+		if err != nil || len(ifaceV6Addrs) == 0 {
+			return nil, fmt.Errorf("failed to find IPv6 address for interface %s", iface.Name)
+		}
+		ifaceV6Addr = ifaceV6Addrs[0]
+	} else if ipStack == DualStack && ifaceAddr == nil && ifaceV6Addr == nil {
+		ifaceAddrs, err = ip.GetInterfaceIP4Addr(iface)
+		if err != nil || len(ifaceAddrs) == 0 {
+			return nil, fmt.Errorf("failed to find IPv4 address for interface %s", iface.Name)
+		}
+		ifaceAddr = ifaceAddrs[0]
+		ifaceV6Addrs, err = ip.GetInterfaceIP6Addr(iface)
+		if err != nil || len(ifaceV6Addrs) == 0 {
+			return nil, fmt.Errorf("failed to find IPv6 address for interface %s", iface.Name)
+		}
+		ifaceV6Addr = ifaceV6Addrs[0]
+	}
+
+	if ifaceAddr != nil {
+		log.Infof("Using interface with name %s and address %s", iface.Name, ifaceAddr)
+	}
+	if ifaceV6Addr != nil {
+		log.Infof("Using interface with name %s and v6 address %s", iface.Name, ifaceV6Addr)
+	}
+
+	if iface.MTU == 0 {
+		return nil, fmt.Errorf("failed to determine MTU for %s interface", ifaceAddr)
+	}
+
+	var extAddr net.IP
+	var extV6Addr net.IP
+
+	if len(opts.PublicIP) > 0 {
+		extAddr = net.ParseIP(opts.PublicIP)
+		if extAddr == nil {
+			return nil, fmt.Errorf("invalid public IP address: %s", opts.PublicIP)
+		}
+		log.Infof("Using %s as external address", extAddr)
+	}
+
+	if extAddr == nil {
+		log.Infof("Defaulting external address to interface address (%s)", ifaceAddr)
+		extAddr = ifaceAddr
+	}
+
+	if len(opts.PublicIPv6) > 0 {
+		extV6Addr = net.ParseIP(opts.PublicIPv6)
+		if extV6Addr == nil {
+			return nil, fmt.Errorf("invalid public IPv6 address: %s", opts.PublicIPv6)
+		}
+		log.Infof("Using %s as external address", extV6Addr)
+	}
+
+	if extV6Addr == nil {
+		log.Infof("Defaulting external v6 address to interface address (%s)", ifaceV6Addr)
+		extV6Addr = ifaceV6Addr
+	}
+
+	return &backend.ExternalInterface{
+		Iface:       iface,
+		IfaceAddr:   ifaceAddr,
+		IfaceV6Addr: ifaceV6Addr,
+		ExtAddr:     extAddr,
+		ExtV6Addr:   extV6Addr,
+	}, nil
+}
+
+func matchIP(ifregex *regexp.Regexp, ifaceIPs []net.IP) net.IP {
+	for _, ifaceIP := range ifaceIPs {
+		if ifregex.MatchString(ifaceIP.String()) {
+			return ifaceIP
+		}
+	}
+	return nil
+}

--- a/pkg/ipmatch/match.go
+++ b/pkg/ipmatch/match.go
@@ -98,7 +98,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 		for _, ifaceToMatch := range ifaces {
 			switch ipStack {
 			case IPv4Stack:
-				ifaceIPs, err := ip.GetInterfaceIP4Addr(&ifaceToMatch)
+				ifaceIPs, err := ip.GetInterfaceIP4Addrs(&ifaceToMatch)
 				if err != nil {
 					// Skip if there is no IPv4 address
 					continue
@@ -109,7 +109,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 					break ifaceLoop
 				}
 			case IPv6Stack:
-				ifaceIPs, err := ip.GetInterfaceIP6Addr(&ifaceToMatch)
+				ifaceIPs, err := ip.GetInterfaceIP6Addrs(&ifaceToMatch)
 				if err != nil {
 					// Skip if there is no IPv6 address
 					continue
@@ -120,13 +120,13 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 					break ifaceLoop
 				}
 			case DualStack:
-				ifaceIPs, err := ip.GetInterfaceIP4Addr(&ifaceToMatch)
+				ifaceIPs, err := ip.GetInterfaceIP4Addrs(&ifaceToMatch)
 				if err != nil {
 					// Skip if there is no IPv4 address
 					continue
 				}
 
-				ifaceV6IPs, err := ip.GetInterfaceIP6Addr(&ifaceToMatch)
+				ifaceV6IPs, err := ip.GetInterfaceIP6Addrs(&ifaceToMatch)
 				if err != nil {
 					// Skip if there is no IPv6 address
 					continue
@@ -162,9 +162,9 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 				var ipaddr []net.IP
 				switch ipStack {
 				case IPv4Stack, DualStack:
-					ipaddr, _ = ip.GetInterfaceIP4Addr(&f) // We can safely ignore errors. We just won't log any ip
+					ipaddr, _ = ip.GetInterfaceIP4Addrs(&f) // We can safely ignore errors. We just won't log any ip
 				case IPv6Stack:
-					ipaddr, _ = ip.GetInterfaceIP6Addr(&f) // We can safely ignore errors. We just won't log any ip
+					ipaddr, _ = ip.GetInterfaceIP6Addrs(&f) // We can safely ignore errors. We just won't log any ip
 				}
 				availableFaces = append(availableFaces, fmt.Sprintf("%s:%v", f.Name, ipaddr))
 			}
@@ -200,24 +200,24 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 	var ifaceAddrs []net.IP
 	var ifaceV6Addrs []net.IP
 	if ipStack == IPv4Stack && ifaceAddr == nil {
-		ifaceAddrs, err = ip.GetInterfaceIP4Addr(iface)
+		ifaceAddrs, err = ip.GetInterfaceIP4Addrs(iface)
 		if err != nil || len(ifaceAddrs) == 0 {
 			return nil, fmt.Errorf("failed to find IPv4 address for interface %s", iface.Name)
 		}
 		ifaceAddr = ifaceAddrs[0]
 	} else if ipStack == IPv6Stack && ifaceV6Addr == nil {
-		ifaceV6Addrs, err = ip.GetInterfaceIP6Addr(iface)
+		ifaceV6Addrs, err = ip.GetInterfaceIP6Addrs(iface)
 		if err != nil || len(ifaceV6Addrs) == 0 {
 			return nil, fmt.Errorf("failed to find IPv6 address for interface %s", iface.Name)
 		}
 		ifaceV6Addr = ifaceV6Addrs[0]
 	} else if ipStack == DualStack && ifaceAddr == nil && ifaceV6Addr == nil {
-		ifaceAddrs, err = ip.GetInterfaceIP4Addr(iface)
+		ifaceAddrs, err = ip.GetInterfaceIP4Addrs(iface)
 		if err != nil || len(ifaceAddrs) == 0 {
 			return nil, fmt.Errorf("failed to find IPv4 address for interface %s", iface.Name)
 		}
 		ifaceAddr = ifaceAddrs[0]
-		ifaceV6Addrs, err = ip.GetInterfaceIP6Addr(iface)
+		ifaceV6Addrs, err = ip.GetInterfaceIP6Addrs(iface)
 		if err != nil || len(ifaceV6Addrs) == 0 {
 			return nil, fmt.Errorf("failed to find IPv6 address for interface %s", iface.Name)
 		}

--- a/pkg/ipmatch/match.go
+++ b/pkg/ipmatch/match.go
@@ -260,7 +260,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 		log.Infof("Using %s as external address", extAddr)
 	}
 
-	if extAddr == nil {
+	if extAddr == nil && ipStack != ipv6Stack {
 		log.Infof("Defaulting external address to interface address (%s)", ifaceAddr)
 		extAddr = ifaceAddr
 	}
@@ -273,7 +273,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int, opts PublicIPOp
 		log.Infof("Using %s as external address", extV6Addr)
 	}
 
-	if extV6Addr == nil {
+	if extV6Addr == nil && ipStack != ipv4Stack {
 		log.Infof("Defaulting external v6 address to interface address (%s)", ifaceV6Addr)
 		extV6Addr = ifaceV6Addr
 	}

--- a/pkg/ipmatch/match_test.go
+++ b/pkg/ipmatch/match_test.go
@@ -44,7 +44,7 @@ func TestLookupExtIface(t *testing.T) {
 	}()
 
 	t.Run("ByIfRegexForIPv4", func(t *testing.T) {
-		backendInterface, err := LookupExtIface("", `192\.168\.200\.\d+`, IPv4Stack, PublicIPOpts{})
+		backendInterface, err := LookupExtIface("", `192\.168\.200\.\d+`, ipv4Stack, PublicIPOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -59,7 +59,7 @@ func TestLookupExtIface(t *testing.T) {
 	})
 
 	t.Run("ByIfRegexForName", func(t *testing.T) {
-		backendInterface, err := LookupExtIface("", `dummy\d+`, IPv4Stack, PublicIPOpts{})
+		backendInterface, err := LookupExtIface("", `dummy\d+`, ipv4Stack, PublicIPOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -74,7 +74,7 @@ func TestLookupExtIface(t *testing.T) {
 	})
 
 	t.Run("ByName", func(t *testing.T) {
-		backendInterface, err := LookupExtIface("dummy0", "", IPv4Stack, PublicIPOpts{})
+		backendInterface, err := LookupExtIface("dummy0", "", ipv4Stack, PublicIPOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -89,7 +89,7 @@ func TestLookupExtIface(t *testing.T) {
 	})
 
 	t.Run("ByIPv4", func(t *testing.T) {
-		backendInterface, err := LookupExtIface("172.16.30.18", "", IPv4Stack, PublicIPOpts{})
+		backendInterface, err := LookupExtIface("172.16.30.18", "", ipv4Stack, PublicIPOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -107,7 +107,7 @@ func TestLookupExtIface(t *testing.T) {
 		expectedIfaceName := "dummy0"
 		expectedIP := "172.16.30.18"
 		expectedPublicIP := "172.16.31.200"
-		backendInterface, err := LookupExtIface("", `172\.16\.30\.\d+`, IPv4Stack, PublicIPOpts{
+		backendInterface, err := LookupExtIface("", `172\.16\.30\.\d+`, ipv4Stack, PublicIPOpts{
 			PublicIP: expectedPublicIP,
 		})
 		if err != nil {

--- a/pkg/ipmatch/match_test.go
+++ b/pkg/ipmatch/match_test.go
@@ -1,0 +1,114 @@
+//go:build !windows
+// +build !windows
+
+package ipmatch
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestLookupExtIface(t *testing.T) {
+	var err error
+
+	var execOrFail = func(name string, arg ...string) {
+		err = exec.Command(name, arg...).Run()
+		if err != nil {
+			t.Fatalf("exec ip link command failed.\nmaybe you need adjust sudo config to allow user exec root command without input password.\nerr=%v", err)
+		}
+	}
+	execOrFail("sudo", "ip", "link", "add", "name", "dummy0", "type", "dummy")
+	execOrFail("sudo", "ip", "addr", "add", "1.10.100.1", "dev", "dummy0")
+	execOrFail("sudo", "ip", "addr", "add", "192.168.200.128", "dev", "dummy0")
+	execOrFail("sudo", "ip", "addr", "add", "172.16.30.18", "dev", "dummy0")
+	execOrFail("sudo", "ip", "addr", "add", "172.16.31.200", "dev", "dummy0")
+	execOrFail("sudo", "ip", "link", "set", "dummy0", "up")
+
+	defer func() {
+		exec.Command("sudo", "ip", "link", "set", "dummy0", "down").Run()
+		exec.Command("sudo", "ip", "link", "delete", "dummy0").Run()
+	}()
+
+	t.Run("ByIfRegexForIPv4", func(t *testing.T) {
+		backendInterface, err := LookupExtIface("", `192\.168\.200\.\d+`, IPv4Stack, PublicIPOpts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("backendInterface=%+v iface=%+v", backendInterface, *backendInterface.Iface)
+
+		if backendInterface.Iface.Name != "dummy0" {
+			t.Fatalf("iface name not equal, expected=%v actual=%v", "dummy0", backendInterface.Iface.Name)
+		}
+		if backendInterface.IfaceAddr.String() != "192.168.200.128" {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "192.168.200.128", backendInterface.IfaceAddr.String())
+		}
+	})
+
+	t.Run("ByIfRegexForName", func(t *testing.T) {
+		backendInterface, err := LookupExtIface("", `dummy\d+`, IPv4Stack, PublicIPOpts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("backendInterface=%+v iface=%+v", backendInterface, *backendInterface.Iface)
+
+		if backendInterface.Iface.Name != "dummy0" {
+			t.Fatalf("iface name not equal, expected=%v actual=%v", "dummy0", backendInterface.Iface.Name)
+		}
+		if backendInterface.IfaceAddr.String() != "1.10.100.1" {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "1.10.100.1", backendInterface.IfaceAddr.String())
+		}
+	})
+
+	t.Run("ByName", func(t *testing.T) {
+		backendInterface, err := LookupExtIface("dummy0", "", IPv4Stack, PublicIPOpts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("backendInterface=%+v iface=%+v", backendInterface, *backendInterface.Iface)
+
+		if backendInterface.Iface.Name != "dummy0" {
+			t.Fatalf("iface name not equal, expected=%v actual=%v", "dummy0", backendInterface.Iface.Name)
+		}
+		if backendInterface.IfaceAddr.String() != "1.10.100.1" {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "1.10.100.1", backendInterface.IfaceAddr.String())
+		}
+	})
+
+	t.Run("ByIPv4", func(t *testing.T) {
+		backendInterface, err := LookupExtIface("172.16.30.18", "", IPv4Stack, PublicIPOpts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("backendInterface=%+v iface=%+v", backendInterface, *backendInterface.Iface)
+
+		if backendInterface.Iface.Name != "dummy0" {
+			t.Fatalf("iface name not equal, expected=%v actual=%v", "dummy0", backendInterface.Iface.Name)
+		}
+		if backendInterface.IfaceAddr.String() != "172.16.30.18" {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "172.16.30.18", backendInterface.IfaceAddr.String())
+		}
+	})
+
+	t.Run("ByIfRegexMatchPublicIPv4", func(t *testing.T) {
+		expectedIfaceName := "dummy0"
+		expectedIP := "172.16.30.18"
+		expectedPublicIP := "172.16.31.200"
+		backendInterface, err := LookupExtIface("", `172\.16\.30\.\d+`, IPv4Stack, PublicIPOpts{
+			PublicIP: expectedPublicIP,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("backendInterface=%+v iface=%+v", backendInterface, *backendInterface.Iface)
+
+		if backendInterface.Iface.Name != "dummy0" {
+			t.Fatalf("iface name not equal, expected=%v actual=%v", expectedIfaceName, backendInterface.Iface.Name)
+		}
+		if backendInterface.IfaceAddr.String() != expectedIP {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", expectedIP, backendInterface.IfaceAddr.String())
+		}
+		if backendInterface.ExtAddr.String() != expectedPublicIP {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", expectedPublicIP, backendInterface.ExtAddr.String())
+		}
+	})
+}

--- a/pkg/ipmatch/match_test.go
+++ b/pkg/ipmatch/match_test.go
@@ -1,6 +1,20 @@
 //go:build !windows
 // +build !windows
 
+// Copyright 2022 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package ipmatch
 
 import (

--- a/pkg/ipmatch/match_test.go
+++ b/pkg/ipmatch/match_test.go
@@ -25,7 +25,7 @@ import (
 func TestLookupExtIface(t *testing.T) {
 	var err error
 
-	var execOrFail = func(name string, arg ...string) {
+	execOrFail := func(name string, arg ...string) {
 		err = exec.Command(name, arg...).Run()
 		if err != nil {
 			t.Fatalf("exec ip link command failed.\nmaybe you need adjust sudo config to allow user exec root command without input password.\nerr=%v", err)
@@ -39,8 +39,8 @@ func TestLookupExtIface(t *testing.T) {
 	execOrFail("sudo", "ip", "link", "set", "dummy0", "up")
 
 	defer func() {
-		exec.Command("sudo", "ip", "link", "set", "dummy0", "down").Run()
-		exec.Command("sudo", "ip", "link", "delete", "dummy0").Run()
+		_ = exec.Command("sudo", "ip", "link", "set", "dummy0", "down").Run()
+		_ = exec.Command("sudo", "ip", "link", "delete", "dummy0").Run()
 	}()
 
 	t.Run("ByIfRegexForIPv4", func(t *testing.T) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

resolve  https://github.com/flannel-io/flannel/issues/981

if interface has multi IPs, current match implementation will failed to get the right IP.

for example, interface `dummy0` has 4 IPs:

```
1.10.100.1
192.168.200.128
172.16.30.18
172.16.31.200
```
we expect to use `192\.168\.200\.\d+` as `--iface-regex` option to get  `192.168.200.128` matched.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
