### PR TITLE
Ipv6 only support

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -105,3 +105,7 @@ FLANNEL_IPV6_SUBNET=2001:cafe:42::1/64
 FLANNEL_MTU=1450
 FLANNEL_IPMASQ=true
 ```
+
+## IPv6 only
+
+To use an IPv6 only environment use the same configuration of the Dual-stack to enable IPv6 and add "EnableIPv4": false in the net-conf.json of the kube-flannel-cfg ConfigMap

--- a/main.go
+++ b/main.go
@@ -716,7 +716,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int) (*backend.Exter
 		log.Infof("Using %s as external address", extAddr)
 	}
 
-	if extAddr == nil {
+	if extAddr == nil && ipStack != ipv6Stack {
 		log.Infof("Defaulting external address to interface address (%s)", ifaceAddr)
 		extAddr = ifaceAddr
 	}
@@ -729,7 +729,7 @@ func LookupExtIface(ifname string, ifregexS string, ipStack int) (*backend.Exter
 		log.Infof("Using %s as external address", extV6Addr)
 	}
 
-	if extV6Addr == nil {
+	if extV6Addr == nil && ipStack != ipv4Stack {
 		log.Infof("Defaulting external v6 address to interface address (%s)", ifaceV6Addr)
 		extV6Addr = ifaceV6Addr
 	}

--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -349,7 +349,7 @@ func (ksm *kubeSubnetManager) AcquireLease(ctx context.Context, attrs *subnet.Le
 		Attrs:      *attrs,
 		Expiration: time.Now().Add(24 * time.Hour),
 	}
-	if cidr != nil {
+	if cidr != nil && ksm.enableIPv4 {
 		lease.Subnet = ip.FromIPNet(cidr)
 	}
 	if ipv6Cidr != nil {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
It partially resolves #1453 in case of kube as subnet manager, etcd support is still missing.
IPv4 is always enabled by default to disable it add `"EnableIPv4": false` on the net-conf.json.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
