### PR TITLE
Add --iface-can-reach option as new way to decide IF

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -69,7 +69,7 @@ The following configuration illustrates the use of most options with `udp` backe
 --kube-subnet-mgr: Contact the Kubernetes API for subnet assignment instead of etcd.
 --iface="": interface to use (IP or name) for inter-host communication. Defaults to the interface for the default route on the machine. This can be specified multiple times to check each option in order. Returns the first match found.
 --iface-regex="": regex expression to match the first interface to use (IP or name) for inter-host communication. If unspecified, will default to the interface for the default route on the machine. This can be specified multiple times to check each regex in order. Returns the first match found. This option is superseded by the iface option and will only be used if nothing matches any option specified in the iface options.
---iface-can-reach="": detect interface to use (IP or name) for inter-host communication based on which will be used for provided IP. This is exactly the interface to use of command "ip route get <ip-address>"
+--iface-can-reach="": detect interface to use (IP or name) for inter-host communication based on which will be used for provided IP. This is exactly the interface to use of command "ip route get <ip-address>" (example: --iface-can-reach=192.168.1.1 results the interface can be reached to 192.168.1.1 will be selected)
 --iptables-resync=5: resync period for iptables rules, in seconds. Defaults to 5 seconds, if you see a large amount of contention for the iptables lock increasing this will probably help.
 --subnet-file=/run/flannel/subnet.env: filename where env variables (subnet and MTU values) will be written to.
 --net-config-path=/etc/kube-flannel/net-conf.json: path to the network configuration file to use

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -69,7 +69,7 @@ The following configuration illustrates the use of most options with `udp` backe
 --kube-subnet-mgr: Contact the Kubernetes API for subnet assignment instead of etcd.
 --iface="": interface to use (IP or name) for inter-host communication. Defaults to the interface for the default route on the machine. This can be specified multiple times to check each option in order. Returns the first match found.
 --iface-regex="": regex expression to match the first interface to use (IP or name) for inter-host communication. If unspecified, will default to the interface for the default route on the machine. This can be specified multiple times to check each regex in order. Returns the first match found. This option is superseded by the iface option and will only be used if nothing matches any option specified in the iface options.
---iface-can-reach="": detect interface to use (IP or name) for inter-host communication based on which will be used for provided IP. This is exactly the interface to use of command "ip route get <ip-addres>"
+--iface-can-reach="": detect interface to use (IP or name) for inter-host communication based on which will be used for provided IP. This is exactly the interface to use of command "ip route get <ip-address>"
 --iptables-resync=5: resync period for iptables rules, in seconds. Defaults to 5 seconds, if you see a large amount of contention for the iptables lock increasing this will probably help.
 --subnet-file=/run/flannel/subnet.env: filename where env variables (subnet and MTU values) will be written to.
 --net-config-path=/etc/kube-flannel/net-conf.json: path to the network configuration file to use

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -69,6 +69,7 @@ The following configuration illustrates the use of most options with `udp` backe
 --kube-subnet-mgr: Contact the Kubernetes API for subnet assignment instead of etcd.
 --iface="": interface to use (IP or name) for inter-host communication. Defaults to the interface for the default route on the machine. This can be specified multiple times to check each option in order. Returns the first match found.
 --iface-regex="": regex expression to match the first interface to use (IP or name) for inter-host communication. If unspecified, will default to the interface for the default route on the machine. This can be specified multiple times to check each regex in order. Returns the first match found. This option is superseded by the iface option and will only be used if nothing matches any option specified in the iface options.
+--iface-can-reach="": detect interface to use (IP or name) for inter-host communication based on which will be used for provided IP. This is exactly the interface to use of command "ip route get <ip-addres>"
 --iptables-resync=5: resync period for iptables rules, in seconds. Defaults to 5 seconds, if you see a large amount of contention for the iptables lock increasing this will probably help.
 --subnet-file=/run/flannel/subnet.env: filename where env variables (subnet and MTU values) will be written to.
 --net-config-path=/etc/kube-flannel/net-conf.json: path to the network configuration file to use

--- a/main.go
+++ b/main.go
@@ -116,7 +116,7 @@ func init() {
 	flannelFlags.StringVar(&opts.etcdPassword, "etcd-password", "", "password for BasicAuth to etcd")
 	flannelFlags.Var(&opts.iface, "iface", "interface to use (IP or name) for inter-host communication. Can be specified multiple times to check each option in order. Returns the first match found.")
 	flannelFlags.Var(&opts.ifaceRegex, "iface-regex", "regex expression to match the first interface to use (IP or name) for inter-host communication. Can be specified multiple times to check each regex in order. Returns the first match found. Regexes are checked after specific interfaces specified by the iface option have already been checked.")
-	flannelFlags.StringVar(&opts.ifaceCanReach, "iface-can-reach", "", "detect interface to use (IP or name) for inter-host communication based on which will be used for provided IP. This is exactly the interface to use of command 'ip route get <ip-addres>'")
+	flannelFlags.StringVar(&opts.ifaceCanReach, "iface-can-reach", "", "detect interface to use (IP or name) for inter-host communication based on which will be used for provided IP. This is exactly the interface to use of command 'ip route get <ip-address>'")
 	flannelFlags.StringVar(&opts.subnetFile, "subnet-file", "/run/flannel/subnet.env", "filename where env variables (subnet, MTU, ... ) will be written to")
 	flannelFlags.StringVar(&opts.publicIP, "public-ip", "", "IP accessible by other nodes for inter-host communication")
 	flannelFlags.StringVar(&opts.publicIPv6, "public-ipv6", "", "IPv6 accessible by other nodes for inter-host communication")

--- a/main.go
+++ b/main.go
@@ -86,6 +86,7 @@ type CmdLineOpts struct {
 	iface                     flagSlice
 	ifaceRegex                flagSlice
 	ipMasq                    bool
+	ifaceCanReach             string
 	subnetFile                string
 	publicIP                  string
 	publicIPv6                string
@@ -115,6 +116,7 @@ func init() {
 	flannelFlags.StringVar(&opts.etcdPassword, "etcd-password", "", "password for BasicAuth to etcd")
 	flannelFlags.Var(&opts.iface, "iface", "interface to use (IP or name) for inter-host communication. Can be specified multiple times to check each option in order. Returns the first match found.")
 	flannelFlags.Var(&opts.ifaceRegex, "iface-regex", "regex expression to match the first interface to use (IP or name) for inter-host communication. Can be specified multiple times to check each regex in order. Returns the first match found. Regexes are checked after specific interfaces specified by the iface option have already been checked.")
+	flannelFlags.StringVar(&opts.ifaceCanReach, "iface-can-reach", "", "detect interface to use (IP or name) for inter-host communication based on which will be used for provided IP. This is exactly the interface to use of command 'ip route get <ip-addres>'")
 	flannelFlags.StringVar(&opts.subnetFile, "subnet-file", "/run/flannel/subnet.env", "filename where env variables (subnet, MTU, ... ) will be written to")
 	flannelFlags.StringVar(&opts.publicIP, "public-ip", "", "IP accessible by other nodes for inter-host communication")
 	flannelFlags.StringVar(&opts.publicIPv6, "public-ipv6", "", "IPv6 accessible by other nodes for inter-host communication")
@@ -262,8 +264,8 @@ func main() {
 		PublicIPv6: opts.publicIPv6,
 	}
 	// Check the default interface only if no interfaces are specified
-	if len(opts.iface) == 0 && len(opts.ifaceRegex) == 0 {
-		extIface, err = ipmatch.LookupExtIface(opts.publicIP, "", ipStack, optsPublicIP)
+	if len(opts.iface) == 0 && len(opts.ifaceRegex) == 0 && len(opts.ifaceCanReach) == 0 {
+		extIface, err = ipmatch.LookupExtIface(opts.publicIP, "", "", ipStack, optsPublicIP)
 		if err != nil {
 			log.Error("Failed to find any valid interface to use: ", err)
 			os.Exit(1)
@@ -271,7 +273,7 @@ func main() {
 	} else {
 		// Check explicitly specified interfaces
 		for _, iface := range opts.iface {
-			extIface, err = ipmatch.LookupExtIface(iface, "", ipStack, optsPublicIP)
+			extIface, err = ipmatch.LookupExtIface(iface, "", "", ipStack, optsPublicIP)
 			if err != nil {
 				log.Infof("Could not find valid interface matching %s: %s", iface, err)
 			}
@@ -284,7 +286,7 @@ func main() {
 		// Check interfaces that match any specified regexes
 		if extIface == nil {
 			for _, ifaceRegex := range opts.ifaceRegex {
-				extIface, err = ipmatch.LookupExtIface("", ifaceRegex, ipStack, optsPublicIP)
+				extIface, err = ipmatch.LookupExtIface("", ifaceRegex, "", ipStack, optsPublicIP)
 				if err != nil {
 					log.Infof("Could not find valid interface matching %s: %s", ifaceRegex, err)
 				}
@@ -292,6 +294,13 @@ func main() {
 				if extIface != nil {
 					break
 				}
+			}
+		}
+
+		if extIface == nil && len(opts.ifaceCanReach) > 0 {
+			extIface, err = ipmatch.LookupExtIface("", "", opts.ifaceCanReach, ipStack, optsPublicIP)
+			if err != nil {
+				log.Infof("Could not find valid interface matching ifaceCanReach: %s: %s", opts.ifaceCanReach, err)
 			}
 		}
 

--- a/pkg/ip/iface.go
+++ b/pkg/ip/iface.go
@@ -239,8 +239,9 @@ func GetInterfaceBySpecificIPRouting(ip net.IP) (*net.Interface, net.IP, error) 
 		iface, err := net.InterfaceByIndex(route.LinkIndex)
 		if err != nil {
 			return nil, nil, fmt.Errorf("couldn't lookup interface: %v", err)
+		} else {
+			return iface, route.Src, nil
 		}
-		return iface, route.Src, nil
 	}
 
 	return nil, nil, errors.New("No interface with given IP found")

--- a/pkg/ip/iface.go
+++ b/pkg/ip/iface.go
@@ -229,6 +229,19 @@ func GetInterfaceByIP6(ip net.IP) (*net.Interface, error) {
 	return nil, errors.New("No interface with given IPv6 found")
 }
 
+func GetInterfaceBySpecificIPRouting(ip net.IP) (*net.Interface, error) {
+	routes, err := netlink.RouteGet(ip)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't lookup route to %v: %v", ip, err)
+	}
+
+	for _, route := range routes {
+		return net.InterfaceByIndex(route.LinkIndex)
+	}
+
+	return nil, errors.New("No interface with given IP found")
+}
+
 func DirectRouting(ip net.IP) (bool, error) {
 	routes, err := netlink.RouteGet(ip)
 	if err != nil {

--- a/pkg/ip/iface.go
+++ b/pkg/ip/iface.go
@@ -229,17 +229,21 @@ func GetInterfaceByIP6(ip net.IP) (*net.Interface, error) {
 	return nil, errors.New("No interface with given IPv6 found")
 }
 
-func GetInterfaceBySpecificIPRouting(ip net.IP) (*net.Interface, error) {
+func GetInterfaceBySpecificIPRouting(ip net.IP) (*net.Interface, net.IP, error) {
 	routes, err := netlink.RouteGet(ip)
 	if err != nil {
-		return nil, fmt.Errorf("couldn't lookup route to %v: %v", ip, err)
+		return nil, nil, fmt.Errorf("couldn't lookup route to %v: %v", ip, err)
 	}
 
 	for _, route := range routes {
-		return net.InterfaceByIndex(route.LinkIndex)
+		iface, err := net.InterfaceByIndex(route.LinkIndex)
+		if err != nil {
+			return nil, nil, fmt.Errorf("couldn't lookup interface: %v", err)
+		}
+		return iface, route.Src, nil
 	}
 
-	return nil, errors.New("No interface with given IP found")
+	return nil, nil, errors.New("No interface with given IP found")
 }
 
 func DirectRouting(ip net.IP) (bool, error) {

--- a/pkg/ipmatch/match.go
+++ b/pkg/ipmatch/match.go
@@ -188,7 +188,7 @@ func LookupExtIface(ifname string, ifregexS string, ifcanreach string, ipStack i
 		}
 	} else if len(ifcanreach) > 0 {
 		log.Info("Determining interface to use based on given ifcanreach: ", ifcanreach)
-		if iface, err = ip.GetInterfaceBySpecificIPRouting(net.ParseIP(ifcanreach)); err != nil {
+		if iface, ifaceAddr, err = ip.GetInterfaceBySpecificIPRouting(net.ParseIP(ifcanreach)); err != nil {
 			return nil, fmt.Errorf("failed to get ifcanreach based interface: %s", err)
 		}
 	} else {

--- a/pkg/ipmatch/match_test.go
+++ b/pkg/ipmatch/match_test.go
@@ -54,7 +54,7 @@ func TestLookupExtIface(t *testing.T) {
 			t.Fatalf("iface name not equal, expected=%v actual=%v", "dummy0", backendInterface.Iface.Name)
 		}
 		if backendInterface.IfaceAddr.String() != "192.168.200.128" {
-			t.Fatalf("iface addr not equal, expected=%v actual=%v", "192.168.200.128", "", backendInterface.IfaceAddr.String())
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "192.168.200.128", backendInterface.IfaceAddr.String())
 		}
 	})
 

--- a/pkg/ipmatch/match_test.go
+++ b/pkg/ipmatch/match_test.go
@@ -36,8 +36,9 @@ func TestLookupExtIface(t *testing.T) {
 	execOrFail("sudo", "ip", "addr", "add", "192.168.200.128", "dev", "dummy0")
 	execOrFail("sudo", "ip", "addr", "add", "172.16.30.18", "dev", "dummy0")
 	execOrFail("sudo", "ip", "addr", "add", "172.16.31.200", "dev", "dummy0")
+	execOrFail("sudo", "ip", "addr", "add", "172.16.32.100", "dev", "dummy0")
 	execOrFail("sudo", "ip", "link", "set", "dummy0", "up")
-	execOrFail("sudo", "ip", "route", "add", "192.168.1.1", "via", "172.16.30.18", "dev", "dummy0")
+	execOrFail("sudo", "ip", "route", "add", "172.16.32.254", "via", "172.16.32.100", "dev", "dummy0")
 
 	defer func() {
 		_ = exec.Command("sudo", "ip", "link", "set", "dummy0", "down").Run()
@@ -129,8 +130,8 @@ func TestLookupExtIface(t *testing.T) {
 
 	t.Run("ByIfCanReach", func(t *testing.T) {
 		expectedIfaceName := "dummy0"
-		expectedIP := "172.16.30.18"
-		backendInterface, err := LookupExtIface("", "", "192.168.1.1", ipv4Stack, PublicIPOpts{})
+		expectedIP := "172.16.32.100"
+		backendInterface, err := LookupExtIface("", "", "172.16.32.254", ipv4Stack, PublicIPOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/ipmatch/match_test.go
+++ b/pkg/ipmatch/match_test.go
@@ -37,6 +37,7 @@ func TestLookupExtIface(t *testing.T) {
 	execOrFail("sudo", "ip", "addr", "add", "172.16.30.18", "dev", "dummy0")
 	execOrFail("sudo", "ip", "addr", "add", "172.16.31.200", "dev", "dummy0")
 	execOrFail("sudo", "ip", "link", "set", "dummy0", "up")
+	execOrFail("sudo", "ip", "route", "add", "192.168.1.1", "via", "172.16.30.18", "dev", "dummy0")
 
 	defer func() {
 		_ = exec.Command("sudo", "ip", "link", "set", "dummy0", "down").Run()
@@ -123,6 +124,23 @@ func TestLookupExtIface(t *testing.T) {
 		}
 		if backendInterface.ExtAddr.String() != expectedPublicIP {
 			t.Fatalf("iface addr not equal, expected=%v actual=%v", expectedPublicIP, backendInterface.ExtAddr.String())
+		}
+	})
+
+	t.Run("ByIfCanReach", func(t *testing.T) {
+		expectedIfaceName := "dummy0"
+		expectedIP := "172.16.30.18"
+		backendInterface, err := LookupExtIface("", "", "192.168.1.1", ipv4Stack, PublicIPOpts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("backendInterface=%+v iface=%+v", backendInterface, *backendInterface.Iface)
+
+		if backendInterface.Iface.Name != expectedIfaceName {
+			t.Fatalf("iface name not equal, expected=%v actual=%v", expectedIfaceName, backendInterface.Iface.Name)
+		}
+		if backendInterface.IfaceAddr.String() != expectedIP {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", expectedIP, backendInterface.IfaceAddr.String())
 		}
 	})
 }

--- a/pkg/ipmatch/match_test.go
+++ b/pkg/ipmatch/match_test.go
@@ -44,7 +44,7 @@ func TestLookupExtIface(t *testing.T) {
 	}()
 
 	t.Run("ByIfRegexForIPv4", func(t *testing.T) {
-		backendInterface, err := LookupExtIface("", `192\.168\.200\.\d+`, ipv4Stack, PublicIPOpts{})
+		backendInterface, err := LookupExtIface("", `192\.168\.200\.\d+`, "", ipv4Stack, PublicIPOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -54,12 +54,12 @@ func TestLookupExtIface(t *testing.T) {
 			t.Fatalf("iface name not equal, expected=%v actual=%v", "dummy0", backendInterface.Iface.Name)
 		}
 		if backendInterface.IfaceAddr.String() != "192.168.200.128" {
-			t.Fatalf("iface addr not equal, expected=%v actual=%v", "192.168.200.128", backendInterface.IfaceAddr.String())
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "192.168.200.128", "", backendInterface.IfaceAddr.String())
 		}
 	})
 
 	t.Run("ByIfRegexForName", func(t *testing.T) {
-		backendInterface, err := LookupExtIface("", `dummy\d+`, ipv4Stack, PublicIPOpts{})
+		backendInterface, err := LookupExtIface("", `dummy\d+`, "", ipv4Stack, PublicIPOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -74,7 +74,7 @@ func TestLookupExtIface(t *testing.T) {
 	})
 
 	t.Run("ByName", func(t *testing.T) {
-		backendInterface, err := LookupExtIface("dummy0", "", ipv4Stack, PublicIPOpts{})
+		backendInterface, err := LookupExtIface("dummy0", "", "", ipv4Stack, PublicIPOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -89,7 +89,7 @@ func TestLookupExtIface(t *testing.T) {
 	})
 
 	t.Run("ByIPv4", func(t *testing.T) {
-		backendInterface, err := LookupExtIface("172.16.30.18", "", ipv4Stack, PublicIPOpts{})
+		backendInterface, err := LookupExtIface("172.16.30.18", "", "", ipv4Stack, PublicIPOpts{})
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -107,7 +107,7 @@ func TestLookupExtIface(t *testing.T) {
 		expectedIfaceName := "dummy0"
 		expectedIP := "172.16.30.18"
 		expectedPublicIP := "172.16.31.200"
-		backendInterface, err := LookupExtIface("", `172\.16\.30\.\d+`, ipv4Stack, PublicIPOpts{
+		backendInterface, err := LookupExtIface("", `172\.16\.30\.\d+`, "", ipv4Stack, PublicIPOpts{
 			PublicIP: expectedPublicIP,
 		})
 		if err != nil {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
### Type: New feature
### Background
Actually this is similar to Calico's `can-reach=DESTINATION` feature. https://projectcalico.docs.tigera.io/reference/node/configuration#can-reachdestination

maybe background is same, this option is really convenient for the cluster having many kind of nodes.

### Tests
Actually we're using in production cluster.

### Effect
Completely new feature, current feature shouldn't be affected.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
--iface-can-reach is added as new option to decide which interface will be used 
```
