### PR TITLE
Add validation that PodCIDR(s) matches the network specified in the `net-conf.json`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ K8S_VERSION=v1.22.3
 GOARM=7
 
 # These variables can be overridden by setting an environment variable.
-TEST_PACKAGES?=pkg/ip subnet subnet/etcdv2 network backend
+TEST_PACKAGES?=pkg/ip subnet subnet/etcdv2 subnet/kube network backend
 TEST_PACKAGES_EXPANDED=$(TEST_PACKAGES:%=github.com/flannel-io/flannel/%)
 PACKAGES?=$(TEST_PACKAGES) network
 PACKAGES_EXPANDED=$(PACKAGES:%=github.com/flannel-io/flannel/%)

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Flannel can be added to any existing Kubernetes cluster though it's simplest to 
 For Kubernetes v1.17+
 `kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml`
 
+If you use custom `podCIDR` (not `10.244.0.0/16`) you first need to download the above manifest and modify the network to match your one.
+
 See [Kubernetes](Documentation/kubernetes.md) for more details.
 
 ## Getting started on Docker

--- a/dist/functional-test-k8s.sh
+++ b/dist/functional-test-k8s.sh
@@ -81,11 +81,24 @@ start_flannel() {
 
     for host_num in 1 2; do
        docker rm -f flannel-e2e-test-flannel$host_num >/dev/null 2>/dev/null
-       docker run -e NODE_NAME=flannel$host_num --privileged --name flannel-e2e-test-flannel$host_num -id --entrypoint /bin/sh $FLANNEL_DOCKER_IMAGE >/dev/null
-       docker exec flannel-e2e-test-flannel$host_num /bin/sh -c 'mkdir -p /etc/kube-flannel'
-       echo $flannel_conf | docker exec -i flannel-e2e-test-flannel$host_num /bin/sh -c 'cat > /etc/kube-flannel/net-conf.json'
-       docker exec -d flannel-e2e-test-flannel$host_num /opt/bin/flanneld --kube-subnet-mgr --kube-api-url $k8s_endpt
+
+       docker run -id --privileged \
+        -e NODE_NAME=flannel$host_num \
+        --name flannel-e2e-test-flannel$host_num \
+        --entrypoint "/bin/sh" \
+        $FLANNEL_DOCKER_IMAGE \
+        -c "mkdir -p /etc/kube-flannel && \
+            echo '$flannel_conf' > /etc/kube-flannel/net-conf.json && \
+            /opt/bin/flanneld --kube-subnet-mgr --kube-api-url $k8s_endpt" >/dev/null
+
        while ! docker exec flannel-e2e-test-flannel$host_num ls /run/flannel/subnet.env >/dev/null 2>&1; do
+         status=$(docker inspect --format='{{.State.Status}}' flannel-e2e-test-flannel$host_num)
+         if [[ $status != "running" ]]; then
+            docker logs flannel-e2e-test-flannel$host_num
+
+            return
+         fi
+
          sleep 0.1
        done
     done

--- a/subnet/kube/kube.go
+++ b/subnet/kube/kube.go
@@ -350,9 +350,17 @@ func (ksm *kubeSubnetManager) AcquireLease(ctx context.Context, attrs *subnet.Le
 		Expiration: time.Now().Add(24 * time.Hour),
 	}
 	if cidr != nil && ksm.enableIPv4 {
+		if !containsCIDR(ksm.subnetConf.Network.ToIPNet(), cidr) {
+			return nil, fmt.Errorf("subnet %q specified in the flannel net config doesn't contain %q PodCIDR of the %q node.", ksm.subnetConf.Network, cidr, ksm.nodeName)
+		}
+
 		lease.Subnet = ip.FromIPNet(cidr)
 	}
 	if ipv6Cidr != nil {
+		if !containsCIDR(ksm.subnetConf.IPv6Network.ToIPNet(), ipv6Cidr) {
+			return nil, fmt.Errorf("subnet %q specified in the flannel net config doesn't contain %q IPv6 PodCIDR of the %q.", ksm.subnetConf.IPv6Network, ipv6Cidr, ksm.nodeName)
+		}
+
 		lease.IPv6Subnet = ip.FromIP6Net(ipv6Cidr)
 	}
 	//TODO - only vxlan, host-gw and wireguard backends support dual stack now.
@@ -452,4 +460,10 @@ func (ksm *kubeSubnetManager) setNodeNetworkUnavailableFalse(ctx context.Context
 	patch := []byte(fmt.Sprintf(`{"status":{"conditions":%s}}`, raw))
 	_, err = ksm.client.CoreV1().Nodes().PatchStatus(ctx, ksm.nodeName, patch)
 	return err
+}
+
+func containsCIDR(ipnet1, ipnet2 *net.IPNet) bool {
+	ones1, _ := ipnet1.Mask.Size()
+	ones2, _ := ipnet2.Mask.Size()
+	return ones1 <= ones2 && ipnet1.Contains(ipnet2.IP)
 }

--- a/subnet/kube/kube_test.go
+++ b/subnet/kube/kube_test.go
@@ -1,0 +1,52 @@
+// Copyright 2018 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"net"
+
+	"testing"
+)
+
+func TestContainsCIDR(t *testing.T) {
+	testCases := []struct {
+		cidr1          string
+		cidr2          string
+		expectedResult bool
+	}{
+		{"10.244.0.0/16", "10.244.0.0/16", true},
+		{"10.244.0.0/16", "10.244.0.0/24", true},
+		{"10.244.0.0/16", "10.244.255.0/24", true},
+		{"10.244.0.0/16", "10.244.0.0/15", false},
+		{"10.244.0.0/16", "192.168.0.0/24", false},
+
+		{"2001:0db8:1234::/48", "2001:0db8:1234::/48", true},
+		{"2001:0db8:1234::/48", "2001:0db8:1234::/64", true},
+		{"2001:0db8:1234::/48", "2001:0db8:1234:ffff::/64", true},
+		{"2001:0db8:1234::/48", "2001:0db8:1234::/47", false},
+		{"2001:0db8:1234::/48", "fe02::/32", false},
+	}
+
+	for i, tc := range testCases {
+		_, ipnet1, _ := net.ParseCIDR(tc.cidr1)
+		_, ipnet2, _ := net.ParseCIDR(tc.cidr2)
+
+		actualResult := containsCIDR(ipnet1, ipnet2)
+
+		if actualResult != tc.expectedResult {
+			t.Errorf("#%d: Expected %t, but was %t.", i, tc.expectedResult, actualResult)
+		}
+	}
+}


### PR DESCRIPTION
Faced issue that `iptables` forwarding rules have been created for the default subnet from the `net-conf.json` config while actual PodCIDR was different.
