### PR TITLE
Fix etcd key removal in CI and add -e flag

### DIFF
--- a/dist/functional-test.sh
+++ b/dist/functional-test.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-set -x
+#Add "set -xe" to get more information where the unit test fail
+set -xe
 
 ARCH="${ARCH:-amd64}"
 ETCD_IMG="${ETCD_IMG:-quay.io/coreos/etcd:v3.2.7}"
@@ -8,7 +9,7 @@ ETCD_IMG="${ETCD_IMG:-quay.io/coreos/etcd:v3.2.7}"
 ETCDCTL_IMG="quay.io/coreos/etcd:v3.2.7"
 ETCD_LOCATION="${ETCD_LOCATION:-etcd}"
 FLANNEL_NET="${FLANNEL_NET:-10.10.0.0/16}"
-TAG=`git describe --tags --dirty`
+TAG=`git describe --tags --dirty --always`
 FLANNEL_DOCKER_IMAGE="${FLANNEL_DOCKER_IMAGE:-quay.io/coreos/flannel:$TAG}"
 
 # Set the proper imagename according to architecture
@@ -49,7 +50,7 @@ teardown() {
     echo "########## logs for flannel-e2e-test-flannel1 container ##########" 2>&1
     docker logs flannel-e2e-test-flannel1
     docker rm -f flannel-e2e-test-flannel1 flannel-e2e-test-flannel2 flannel-e2e-test-flannel1-iperf flannel-host1 flannel-host2 > /dev/null 2>&1
-    docker run --rm -e ETCDCTL_API=3 $ETCDCTL_IMG etcdctl --endpoints=$etcd_endpt rm /coreos.com/network/config > /dev/null 2>&1
+    docker run --rm -e ETCDCTL_API=3 $ETCDCTL_IMG etcdctl --endpoints=$etcd_endpt del /coreos.com/network/config > /dev/null 2>&1
 }
 
 write_config_etcd() {


### PR DESCRIPTION
Signed-off-by: Manuel Buil <mbuil@suse.com>

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

This PR fixes the CI problem as described in https://github.com/flannel-io/flannel/issues/1594. It changes the etcdctl command from "rm" to "del" which is the correct one for v3. Then, it adds -e bash flag to make sure this error or future ones are not ignored

Besides, add `--always` to git describe or it fails

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
