### PR TITLE
wireguard: fix segmentation fault if only ipv6 is enabled

### DIFF
--- a/backend/wireguard/wireguard.go
+++ b/backend/wireguard/wireguard.go
@@ -140,7 +140,7 @@ func (be *WireguardBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGr
 			if err != nil {
 				return nil, err
 			}
-			publicKey = dev.attrs.publicKey.String()
+			publicKey = v6Dev.attrs.publicKey.String()
 		}
 	} else if cfg.Mode == Auto || cfg.Mode == Ipv4 || cfg.Mode == Ipv6 {
 		dev, err = createWGDev(ctx, wg, "flannel-wg", cfg.PSK, &keepalive, cfg.ListenPort, be.extIface.Iface.MTU)


### PR DESCRIPTION
## Description

Flannel terminates with segmentation fault if you enable only ipv6 in separate mode.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
