### PR TITLE
Set more explicit error message when network config is missing in etcd

### DIFF
--- a/subnet/etcd/registry.go
+++ b/subnet/etcd/registry.go
@@ -36,7 +36,7 @@ import (
 
 var (
 	errTryAgain            = errors.New("try again")
-	errKeyNotFound         = errors.New("key not found")
+	errConfigNotFound      = errors.New("flannel config not found in etcd store. Did you create your config using etcdv3 API?")
 	errNoWatchChannel      = errors.New("no watch channel")
 	errSubnetAlreadyexists = errors.New("subnet already exists")
 )
@@ -153,7 +153,7 @@ func (esr *etcdSubnetRegistry) getNetworkConfig(ctx context.Context) (string, er
 		return "", err
 	}
 	if len(resp.Kvs) == 0 {
-		return "", rpctypes.ErrGRPCKeyNotFound
+		return "", errConfigNotFound
 	}
 
 	return string(resp.Kvs[0].Value), nil
@@ -200,7 +200,7 @@ func (esr *etcdSubnetRegistry) getSubnet(ctx context.Context, sn ip.IP4Net, sn6 
 	}
 
 	if len(resp.Kvs) == 0 {
-		return nil, 0, errKeyNotFound
+		return nil, 0, rpctypes.ErrGRPCKeyNotFound
 	}
 
 	ttlresp, err := esr.cli.TimeToLive(ctx, etcd.LeaseID(resp.Kvs[0].Lease))

--- a/subnet/etcd/registry_test.go
+++ b/subnet/etcd/registry_test.go
@@ -106,7 +106,7 @@ func TestEtcdRegistry(t *testing.T) {
 	r, kvApi := newTestEtcdRegistry(t, ctx, client)
 
 	_, err := r.getNetworkConfig(ctx)
-	if err == nil {
+	if err != errConfigNotFound {
 		t.Fatal("Should hit error getting config")
 	}
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
The PR makes the error message more explicit when flannel config is not found in etcd.
It suggests to check that the config is stored using etcdv3 API since users might not have noticed that we changed the version we are using.

It also removes completely the custom error `errKeyNotFound` which is a duplicate of `rpctypes.ErrGRPCKeyNotFound`.

## Todos
- [ X ] Tests
- [ X] Documentation
- [ X] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
