### PR TITLE
`public-ip-overwrite` using node-labels

### DIFF
--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -29,9 +29,10 @@ Thus, you will need to restrict access to this namespace if you wish to secure y
 If you want to deploy `flannel` securely in a shared namespace or want more fine-grained control over the pods deployed in your cluster, you can use a 3rd-party admission controller like [Kubewarden](https://kubewarden.io). Kubewarden provides policies that can replace features of PodSecurityPolicy like [capabilities-psp-policy](https://github.com/kubewarden/capabilities-psp-policy) and [hostpaths-psp-policy](https://github.com/kubewarden/hostpaths-psp-policy).
 
 Other options include [Kyverno](https://kyverno.io/policies/pod-security/) and [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper).
-# Annotations
 
-*  `flannel.alpha.coreos.com/public-ip-overwrite`: Allows to overwrite the public IP of a node. Useful if the public IP can not determined from the node, e.G. because it is behind a NAT. It can be automatically set to a nodes `ExternalIP` using the [flannel-node-annotator](https://github.com/alvaroaleman/flannel-node-annotator)
+# Annotations and Labels
+
+*  `flannel.alpha.coreos.com/public-ip-overwrite` and `flannel.alpha.coreos.com/public-ipv6-overwrite`: Allows to overwrite the public IP of a node. Useful if the public IP can not determined from the node, e.G. because it is behind a NAT. It can be automatically set to a nodes `ExternalIP` using the [flannel-node-annotator](https://github.com/alvaroaleman/flannel-node-annotator)
 
 ## Older versions of Kubernetes
 

--- a/dist/functional-test-k8s.sh
+++ b/dist/functional-test-k8s.sh
@@ -147,7 +147,7 @@ test_ipip() {
     check_iptables
 }
 
-test_public-ip-overwrite(){
+test_public-ip-overwrite_annotation(){
   docker exec flannel-e2e-k8s-apiserver kubectl annotate node flannel1 \
     flannel.alpha.coreos.com/public-ip-overwrite=172.18.0.2 >/dev/null 2>&1
   start_flannel vxlan
@@ -157,6 +157,19 @@ test_public-ip-overwrite(){
     "Overwriting public IP via annotation does not work"
   # Remove annotation to not break all other tests
   docker exec flannel-e2e-k8s-apiserver kubectl annotate node flannel1 \
+    flannel.alpha.coreos.com/public-ip-overwrite- >/dev/null 2>&1
+}
+
+test_public-ip-overwrite_label(){
+  docker exec flannel-e2e-k8s-apiserver kubectl label node flannel1 \
+    flannel.alpha.coreos.com/public-ip-overwrite=172.18.0.2 >/dev/null 2>&1
+  start_flannel vxlan
+  assert_equals "172.18.0.2" \
+    "$(docker exec flannel-e2e-k8s-apiserver kubectl get node/flannel1 -o \
+    jsonpath='{.metadata.labels.flannel\.alpha\.coreos\.com/public-ip}' 2>/dev/null)" \
+    "Overwriting public IP via label does not work"
+  # Remove label to not break all other tests
+  docker exec flannel-e2e-k8s-apiserver kubectl label node flannel1 \
     flannel.alpha.coreos.com/public-ip-overwrite- >/dev/null 2>&1
 }
 


### PR DESCRIPTION
Currently (as far as I know) the only way to overwrite the public-ip in kubernetes mode is via node annotations.
For k3s this means there is no way (I know of) to set the annotation before it will be consumed by the integrated flannel.
In this case k3s would have to be restarted to apply the change which is a deal-breaker for me.

This PR simply allows to configure the exact same overwrite via node-labels.
If both are present, the annotation is preferred.

I have not tested this locally but I added a functional test.