### PR TITLE
Don't put flanneld binary in /opt/bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Though not required, it's recommended that flannel uses the Kubernetes API as it
 Flannel can be added to any existing Kubernetes cluster though it's simplest to add `flannel` before any pods using the pod network have been started.
 
 For Kubernetes v1.17+
-
-1. Make sure a `flanneld` binary exists at `/opt/bin/flanneld` on each node
-2. `kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml`
+```
+kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml
+```
 
 If you use custom `podCIDR` (not `10.244.0.0/16`) you first need to download the above manifest and modify the network to match your one.
 


### PR DESCRIPTION
As several people already pointed out on pull request #1563, the
instructions added in there are not necessary. In fact, blindly following
these instructions actually caused some trouble for me since I ran into
issue #1418 and started debugging that problem before realizing that I
don't actually need the binary in `/opt/bin`.

The pull request also does not provide any reasoning for why this could
be necessary. Given that, and given that many people install Flannel
without doing this, it's probably fair to remove this again to prevent
more people running into the issue I had.

This reverts commit a93a407fb74c52a4db43b0a1bbe1447351831dc0.