### PR TITLE
fix flannel clusterrole

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -22,6 +22,7 @@ rules:
   resources:
   - nodes
   verbs:
+  - get
   - list
   - watch
 - apiGroups:


### PR DESCRIPTION
## Description
fix missing `get` verb on `nodes` in the clusterrole, https://github.com/flannel-io/flannel/pull/1656#discussion_r1024697307

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
```release-note
None required
```
