### PR TITLE
pkg/ip/iface_windows_test.go: fix TestGetInterfaceByIP

### DIFF
--- a/pkg/ip/iface_windows_test.go
+++ b/pkg/ip/iface_windows_test.go
@@ -51,13 +51,15 @@ func TestGetInterfaceByIP(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	iface, err := GetInterfaceByIP(defaultIpv4Addr)
-	if err != nil {
-		t.Fatal(err)
-	}
+	for _, addr := range defaultIpv4Addr {
+		iface, err := GetInterfaceByIP(addr)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-	if iface.Index != defaultIface.Index {
-		t.Fatalf("iface.Index(%d) != defaultIface.Index(%d)", iface.Index, defaultIface.Index)
+		if iface.Index != defaultIface.Index {
+			t.Fatalf("iface.Index(%d) != defaultIface.Index(%d)", iface.Index, defaultIface.Index)
+		}
 	}
 }
 


### PR DESCRIPTION
fix type mismatch in windows test TestGetInterfaceByIP

## Description
GetInterfaceIP4Addrs, used in windows test function TestGetInterfaceByIP (file iface_windows_test.go), returns a slice of IPAddresses. The test is done only for single IP address instead of the returned slice. This leads to a type-mismatch error. To fix this a loop was introduced to check all IP Addresses of the interface.

```release-note
None required
```
