### PR TITLE
Fixed masquerade rule to avoid double NAT bug

### DIFF
--- a/dist/functional-test-k8s.sh
+++ b/dist/functional-test-k8s.sh
@@ -177,6 +177,7 @@ check_iptables() {
 -P POSTROUTING ACCEPT
 -A POSTROUTING -m comment --comment "flanneld masq" -j FLANNEL-POSTRTG
 -N FLANNEL-POSTRTG
+-A FLANNEL-POSTRTG -m mark --mark 0x4000/0x4000 -m comment --comment "flanneld masq" -j RETURN
 -A FLANNEL-POSTRTG -s 10.10.0.0/16 -d 10.10.0.0/16 -m comment --comment "flanneld masq" -j RETURN
 -A FLANNEL-POSTRTG -s 10.10.0.0/16 ! -d 224.0.0.0/4 -m comment --comment "flanneld masq" -j MASQUERADE --random-fully
 -A FLANNEL-POSTRTG ! -s 10.10.0.0/16 -d 10.10.1.0/24 -m comment --comment "flanneld masq" -j RETURN
@@ -186,6 +187,7 @@ EOM
 -P POSTROUTING ACCEPT
 -A POSTROUTING -m comment --comment "flanneld masq" -j FLANNEL-POSTRTG
 -N FLANNEL-POSTRTG
+-A FLANNEL-POSTRTG -m mark --mark 0x4000/0x4000 -m comment --comment "flanneld masq" -j RETURN
 -A FLANNEL-POSTRTG -s 10.10.0.0/16 -d 10.10.0.0/16 -m comment --comment "flanneld masq" -j RETURN
 -A FLANNEL-POSTRTG -s 10.10.0.0/16 ! -d 224.0.0.0/4 -m comment --comment "flanneld masq" -j MASQUERADE --random-fully
 -A FLANNEL-POSTRTG ! -s 10.10.0.0/16 -d 10.10.2.0/24 -m comment --comment "flanneld masq" -j RETURN

--- a/network/iptables.go
+++ b/network/iptables.go
@@ -46,6 +46,8 @@ type IPTablesRule struct {
 	rulespec []string
 }
 
+const kubeProxyMark string = "0x4000/0x4000"
+
 func MasqRules(ipn ip.IP4Net, lease *subnet.Lease) []IPTablesRule {
 	n := ipn.String()
 	sn := lease.Subnet.String()
@@ -59,6 +61,8 @@ func MasqRules(ipn ip.IP4Net, lease *subnet.Lease) []IPTablesRule {
 		return []IPTablesRule{
 			// This rule ensure that the flannel iptables rules are executed before other rules on the node
 			{"nat", "-I", "POSTROUTING", []string{"-m", "comment", "--comment", "flanneld masq", "-j", "FLANNEL-POSTRTG"}},
+			// This rule will not masquerade traffic marked by the kube-proxy to avoid double NAT bug on some kernel version
+			{"nat", "-A", "FLANNEL-POSTRTG", []string{"-m", "mark", "--mark", kubeProxyMark, "-m", "comment", "--comment", "flanneld masq", "-j", "RETURN"}},
 			// This rule makes sure we don't NAT traffic within overlay network (e.g. coming out of docker0)
 			{"nat", "-A", "FLANNEL-POSTRTG", []string{"-s", n, "-d", n, "-m", "comment", "--comment", "flanneld masq", "-j", "RETURN"}},
 			// NAT if it's not multicast traffic
@@ -72,6 +76,8 @@ func MasqRules(ipn ip.IP4Net, lease *subnet.Lease) []IPTablesRule {
 		return []IPTablesRule{
 			// This rule ensure that the flannel iptables rules are executed before other rules on the node
 			{"nat", "-I", "POSTROUTING", []string{"-m", "comment", "--comment", "flanneld masq", "-j", "FLANNEL-POSTRTG"}},
+			// This rule will not masquerade traffic marked by the kube-proxy to avoid double NAT bug on some kernel version
+			{"nat", "-A", "FLANNEL-POSTRTG", []string{"-m", "mark", "--mark", kubeProxyMark, "-m", "comment", "--comment", "flanneld masq", "-j", "RETURN"}},
 			// This rule makes sure we don't NAT traffic within overlay network (e.g. coming out of docker0)
 			{"nat", "-A", "FLANNEL-POSTRTG", []string{"-s", n, "-d", n, "-m", "comment", "--comment", "flanneld masq", "-j", "RETURN"}},
 			// NAT if it's not multicast traffic
@@ -97,6 +103,8 @@ func MasqIP6Rules(ipn ip.IP6Net, lease *subnet.Lease) []IPTablesRule {
 		return []IPTablesRule{
 			// This rule ensure that the flannel iptables rules are executed before other rules on the node
 			{"nat", "-I", "POSTROUTING", []string{"-m", "comment", "--comment", "flanneld masq", "-j", "FLANNEL-POSTRTG"}},
+			// This rule will not masquerade traffic marked by the kube-proxy to avoid double NAT bug on some kernel version
+			{"nat", "-A", "FLANNEL-POSTRTG", []string{"-m", "mark", "--mark", kubeProxyMark, "-m", "comment", "--comment", "flanneld masq", "-j", "RETURN"}},
 			// This rule makes sure we don't NAT traffic within overlay network (e.g. coming out of docker0)
 			{"nat", "-A", "FLANNEL-POSTRTG", []string{"-s", n, "-d", n, "-m", "comment", "--comment", "flanneld masq", "-j", "RETURN"}},
 			// NAT if it's not multicast traffic
@@ -110,6 +118,8 @@ func MasqIP6Rules(ipn ip.IP6Net, lease *subnet.Lease) []IPTablesRule {
 		return []IPTablesRule{
 			// This rule ensure that the flannel iptables rules are executed before other rules on the node
 			{"nat", "-I", "POSTROUTING", []string{"-m", "comment", "--comment", "flanneld masq", "-j", "FLANNEL-POSTRTG"}},
+			// This rule will not masquerade traffic marked by the kube-proxy to avoid double NAT bug on some kernel version
+			{"nat", "-A", "FLANNEL-POSTRTG", []string{"-m", "mark", "--mark", kubeProxyMark, "-m", "comment", "--comment", "flanneld masq", "-j", "RETURN"}},
 			// This rule makes sure we don't NAT traffic within overlay network (e.g. coming out of docker0)
 			{"nat", "-A", "FLANNEL-POSTRTG", []string{"-s", n, "-d", n, "-m", "comment", "--comment", "flanneld masq", "-j", "RETURN"}},
 			// NAT if it's not multicast traffic

--- a/network/iptables_test.go
+++ b/network/iptables_test.go
@@ -130,8 +130,8 @@ func TestDeleteRules(t *testing.T) {
 	if err != nil {
 		t.Error("Error setting up iptables")
 	}
-	if len(ipt.rules) != 5 {
-		t.Errorf("Should be 5 masqRules, there are actually %d: %#v", len(ipt.rules), ipt.rules)
+	if len(ipt.rules) != 6 {
+		t.Errorf("Should be 6 masqRules, there are actually %d: %#v", len(ipt.rules), ipt.rules)
 	}
 
 	iptr.rules = []IPTablesRestoreRules{}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Added iptables rule that check marked packed by Kube-proxy to avoid double-NAT that could slow down the connection or in some kernel versions loss packets.

Issue: #1679

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
