### PR TITLE
Updated documentation

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -123,4 +123,4 @@ FLANNEL_IPMASQ=true
 
 ## IPv6 only
 
-To use an IPv6 only environment use the same configuration of the Dual-stack to enable IPv6 and add "EnableIPv4": false in the net-conf.json of the kube-flannel-cfg ConfigMap
+To use an IPv6 only environment use the same configuration of the Dual-stack to enable IPv6 and add "EnableIPv4": false in the net-conf.json of the kube-flannel-cfg ConfigMap. In case of IPv6 only setup docker.io is translated as IPv4 address when deployed on an IPv6 the image reference repo needs to be updated following the Docker documentations for IPv6 only setup (https://www.docker.com/blog/beta-ipv6-support-on-docker-hub-registry/)

--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -123,4 +123,4 @@ FLANNEL_IPMASQ=true
 
 ## IPv6 only
 
-To use an IPv6 only environment use the same configuration of the Dual-stack to enable IPv6 and add "EnableIPv4": false in the net-conf.json of the kube-flannel-cfg ConfigMap. In case of IPv6 only setup docker.io is translated as IPv4 address when deployed on an IPv6 the image reference repo needs to be updated following the Docker documentations for IPv6 only setup (https://www.docker.com/blog/beta-ipv6-support-on-docker-hub-registry/)
+To use an IPv6-only environment use the same configuration of the Dual-stack section to enable IPv6 and add "EnableIPv4": false in the net-conf.json of the kube-flannel-cfg ConfigMap. In case of IPv6-only setup, please use the docker.io IPv6-only endpoint as described in the following link: https://www.docker.com/blog/beta-ipv6-support-on-docker-hub-registry/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![flannel Logo](logos/flannel-horizontal-color.png)
 
-[![Build Status](https://travis-ci.org/coreos/flannel.png?branch=master)](https://travis-ci.org/coreos/flannel)
+![Build Status](https://github.com/flannel-io/flannel/actions/workflows/build.yaml/badge.svg?branch=master)
 
 Flannel is a simple and easy way to configure a layer 3 network fabric designed for Kubernetes.
 
@@ -33,7 +33,7 @@ Flannel can be added to any existing Kubernetes cluster though it's simplest to 
 
 For Kubernetes v1.17+
 ```
-kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml
+kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/v0.20.2/Documentation/kube-flannel.yml
 ```
 
 If you use custom `podCIDR` (not `10.244.0.0/16`) you first need to download the above manifest and modify the network to match your one.


### PR DESCRIPTION
Update README.md to point to the latest release manifest (#1685) and fixed build status link to point github workflow instead of travis old reference.
Updated IPv6 only documentations (#1674)