### PR TITLE
Reordered iptables rules

### DIFF
--- a/e2e/docker-compose.yml
+++ b/e2e/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       context: .
       args:
         - ARCH=amd64
-    command: server --no-deploy=traefik,metrics-server --flannel-backend=none
+    command: server --no-deploy=traefik,metrics-server --flannel-backend=none --disable-network-policy
     environment:
       - K3S_TOKEN=e2e
     hostname: local-leader

--- a/e2e/run-e2e-tests.sh
+++ b/e2e/run-e2e-tests.sh
@@ -236,26 +236,25 @@ EOM
 EOM
   read -r -d '' FORWARD_RULES << EOM
 -P FORWARD ACCEPT
--A FORWARD -m comment --comment "kube-router netpol - TEMCG2JMHZYE7H7T" -j KUBE-ROUTER-FORWARD
--A FORWARD -m comment --comment "flanneld forward" -j FLANNEL-FWD
 -A FORWARD -m comment --comment "kubernetes forwarding rules" -j KUBE-FORWARD
 -A FORWARD -m conntrack --ctstate NEW -m comment --comment "kubernetes service portals" -j KUBE-SERVICES
 -A FORWARD -m conntrack --ctstate NEW -m comment --comment "kubernetes externally-visible service portals" -j KUBE-EXTERNAL-SERVICES
+-A FORWARD -m comment --comment "flanneld forward" -j FLANNEL-FWD
 -N FLANNEL-FWD
 -A FLANNEL-FWD -s 10.42.0.0/16 -m comment --comment "flanneld forward" -j ACCEPT
 -A FLANNEL-FWD -d 10.42.0.0/16 -m comment --comment "flanneld forward" -j ACCEPT
 EOM
   # check masquerade & forward rules
   assert_equals "$POSTROUTING_RULES_WORKER" \
-                "$(docker exec --privileged local-worker /usr/sbin/iptables -t nat -S POSTROUTING -w 5|grep FLANNEL)
-$(docker exec --privileged local-worker /usr/sbin/iptables -t nat -S FLANNEL-POSTRTG -w 5)" "Host 1 has not expected postrouting rules"
+                "$(docker exec --privileged local-worker /usr/sbin/iptables -t nat -S POSTROUTING | grep FLANNEL)
+$(docker exec --privileged local-worker /usr/sbin/iptables -t nat -S FLANNEL-POSTRTG)" "Host 1 has not expected postrouting rules"
   assert_equals "$POSTROUTING_RULES_LEADER" \
-                "$(docker exec --privileged local-leader /usr/sbin/iptables -t nat -S POSTROUTING -w 5|grep FLANNEL)
-$(docker exec --privileged local-leader /usr/sbin/iptables -t nat -S FLANNEL-POSTRTG -w 5)" "Host 2 has not expected postrouting rules"
+                "$(docker exec --privileged local-leader /usr/sbin/iptables -t nat -S POSTROUTING | grep FLANNEL)
+$(docker exec --privileged local-leader /usr/sbin/iptables -t nat -S FLANNEL-POSTRTG)" "Host 2 has not expected postrouting rules"
   assert_equals "$FORWARD_RULES" \
-                "$(docker exec --privileged local-worker /usr/sbin/iptables -t filter -S FORWARD -w 5)
+                "$(docker exec --privileged local-worker /usr/sbin/iptables -t filter -S FORWARD)
 $(docker exec --privileged local-worker /usr/sbin/iptables -t filter -S FLANNEL-FWD -w 5)" "Host 1 has not expected forward rules"
   assert_equals "$FORWARD_RULES" \
-                "$(docker exec --privileged local-leader /usr/sbin/iptables -t filter -S FORWARD -w 5)
-$(docker exec --privileged local-leader /usr/sbin/iptables -t filter -S FLANNEL-FWD -w 5)" "Host 2 has not expected forward rules"
+                "$(docker exec --privileged local-leader /usr/sbin/iptables -t filter -S FORWARD)
+$(docker exec --privileged local-leader /usr/sbin/iptables -t filter -S FLANNEL-FWD)" "Host 2 has not expected forward rules"
 }

--- a/pkg/iptables/iptables.go
+++ b/pkg/iptables/iptables.go
@@ -57,7 +57,7 @@ func MasqRules(cluster_cidrs []ip.IP4Net, lease *subnet.Lease) []IPTablesRule {
 	}
 	rules := make([]IPTablesRule, 2)
 	// This rule ensure that the flannel iptables rules are executed before other rules on the node
-	rules[0] = IPTablesRule{"nat", "-I", "POSTROUTING", []string{"-m", "comment", "--comment", "flanneld masq", "-j", "FLANNEL-POSTRTG"}}
+	rules[0] = IPTablesRule{"nat", "-A", "POSTROUTING", []string{"-m", "comment", "--comment", "flanneld masq", "-j", "FLANNEL-POSTRTG"}}
 	// This rule will not masquerade traffic marked by the kube-proxy to avoid double NAT bug on some kernel version
 	rules[1] = IPTablesRule{"nat", "-A", "FLANNEL-POSTRTG", []string{"-m", "mark", "--mark", kubeProxyMark, "-m", "comment", "--comment", "flanneld masq", "-j", "RETURN"}}
 	for _, ccidr := range cluster_cidrs {
@@ -96,7 +96,7 @@ func MasqIP6Rules(cluster_cidrs []ip.IP6Net, lease *subnet.Lease) []IPTablesRule
 	rules := make([]IPTablesRule, 2)
 
 	// This rule ensure that the flannel iptables rules are executed before other rules on the node
-	rules[0] = IPTablesRule{"nat", "-I", "POSTROUTING", []string{"-m", "comment", "--comment", "flanneld masq", "-j", "FLANNEL-POSTRTG"}}
+	rules[0] = IPTablesRule{"nat", "-A", "POSTROUTING", []string{"-m", "comment", "--comment", "flanneld masq", "-j", "FLANNEL-POSTRTG"}}
 	// This rule will not masquerade traffic marked by the kube-proxy to avoid double NAT bug on some kernel version
 	rules[1] = IPTablesRule{"nat", "-A", "FLANNEL-POSTRTG", []string{"-m", "mark", "--mark", kubeProxyMark, "-m", "comment", "--comment", "flanneld masq", "-j", "RETURN"}}
 
@@ -132,7 +132,7 @@ func MasqIP6Rules(cluster_cidrs []ip.IP6Net, lease *subnet.Lease) []IPTablesRule
 func ForwardRules(flannelNetwork string) []IPTablesRule {
 	return []IPTablesRule{
 		// This rule ensure that the flannel iptables rules are executed before other rules on the node
-		{"filter", "-I", "FORWARD", []string{"-m", "comment", "--comment", "flanneld forward", "-j", "FLANNEL-FWD"}},
+		{"filter", "-A", "FORWARD", []string{"-m", "comment", "--comment", "flanneld forward", "-j", "FLANNEL-FWD"}},
 		// These rules allow traffic to be forwarded if it is to or from the flannel network range.
 		{"filter", "-A", "FLANNEL-FWD", []string{"-s", flannelNetwork, "-m", "comment", "--comment", "flanneld forward", "-j", "ACCEPT"}},
 		{"filter", "-A", "FLANNEL-FWD", []string{"-d", flannelNetwork, "-m", "comment", "--comment", "flanneld forward", "-j", "ACCEPT"}},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Moved iptables rules from insert to append to be ordered after kube-proxy rules to fix https://github.com/k3s-io/k3s/issues/6691
It will invalidate #1650 in case other rules are already created on the nodes. This is the same behaviour of other CNIs the additional rules outside of kubernetes need to be configured accordingly.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
