### PR TITLE
Added MTU config for vxlan and wireguard

### DIFF
--- a/Documentation/backends.md
+++ b/Documentation/backends.md
@@ -23,6 +23,7 @@ Type and options:
 * `Port` (number): UDP port to use for sending encapsulated packets. On Linux, defaults to kernel default, currently 8472, but on Windows, must be 4789.
 * `GBP` (Boolean): Enable [VXLAN Group Based Policy](https://github.com/torvalds/linux/commit/3511494ce2f3d3b77544c79b87511a4ddb61dc89).  Defaults to `false`. GBP is not supported on Windows
 * `DirectRouting` (Boolean): Enable direct routes (like `host-gw`) when the hosts are on the same subnet. VXLAN will only be used to encapsulate packets to hosts on different subnets. Defaults to `false`. DirectRouting is not supported on Windows.
+* `MTU` (number): Desired MTU for the outgoing packets if not defined the MTU of the external interface is used.
 * `MacPrefix` (String): Only use on Windows, set to the MAC prefix. Defaults to `0E-2A`.
 
 ### host-gw
@@ -43,6 +44,7 @@ Type:
 * `PSK` (string): Optional. The pre shared key to use. Use `wg genpsk` to generate a key.
 * `ListenPort` (int): Optional. The udp port to listen on. Default is `51820`.
 * `ListenPortV6` (int): Optional. The udp port to listen on for ipv6. Default is `51821`.
+* `MTU` (number): Desired MTU for the outgoing packets if not defined the MTU of the external interface is used.
 * `Mode` (string): Optional.
     * separate - Use separate wireguard tunnels for ipv4 and ipv6 (default)
     * auto - Single wireguard tunnel for both address families; autodetermine the preferred peer address

--- a/pkg/backend/vxlan/device.go
+++ b/pkg/backend/vxlan/device.go
@@ -32,6 +32,7 @@ import (
 type vxlanDeviceAttrs struct {
 	vni       uint32
 	name      string
+	MTU       int
 	vtepIndex int
 	vtepAddr  net.IP
 	vtepPort  int
@@ -54,6 +55,7 @@ func newVXLANDevice(devAttrs *vxlanDeviceAttrs) (*vxlanDevice, error) {
 		LinkAttrs: netlink.LinkAttrs{
 			Name:         devAttrs.name,
 			HardwareAddr: hardwareAddr,
+			MTU:          devAttrs.MTU - 50,
 		},
 		VxlanId:      int(devAttrs.vni),
 		VtepDevIndex: devAttrs.vtepIndex,

--- a/pkg/backend/vxlan/vxlan.go
+++ b/pkg/backend/vxlan/vxlan.go
@@ -123,11 +123,13 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGroup,
 	cfg := struct {
 		VNI           int
 		Port          int
+		MTU           int
 		GBP           bool
 		Learning      bool
 		DirectRouting bool
 	}{
 		VNI: defaultVNI,
+		MTU: be.extIface.Iface.MTU,
 	}
 
 	if len(config.Backend) > 0 {
@@ -143,6 +145,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGroup,
 		devAttrs := vxlanDeviceAttrs{
 			vni:       uint32(cfg.VNI),
 			name:      fmt.Sprintf("flannel.%v", cfg.VNI),
+			MTU:       cfg.MTU,
 			vtepIndex: be.extIface.Iface.Index,
 			vtepAddr:  be.extIface.IfaceAddr,
 			vtepPort:  cfg.Port,
@@ -160,6 +163,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGroup,
 		v6DevAttrs := vxlanDeviceAttrs{
 			vni:       uint32(cfg.VNI),
 			name:      fmt.Sprintf("flannel-v6.%v", cfg.VNI),
+			MTU:       cfg.MTU,
 			vtepIndex: be.extIface.Iface.Index,
 			vtepAddr:  be.extIface.IfaceV6Addr,
 			vtepPort:  cfg.Port,
@@ -208,7 +212,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGroup,
 			return nil, fmt.Errorf("failed to configure interface %s: %w", v6Dev.link.Attrs().Name, err)
 		}
 	}
-	return newNetwork(be.subnetMgr, be.extIface, dev, v6Dev, ip.IP4Net{}, lease)
+	return newNetwork(be.subnetMgr, be.extIface, dev, v6Dev, ip.IP4Net{}, lease, cfg.MTU)
 }
 
 // So we can make it JSON (un)marshalable

--- a/pkg/backend/vxlan/vxlan_network.go
+++ b/pkg/backend/vxlan/vxlan_network.go
@@ -36,13 +36,14 @@ type network struct {
 	dev       *vxlanDevice
 	v6Dev     *vxlanDevice
 	subnetMgr subnet.Manager
+	mtu       int
 }
 
 const (
 	encapOverhead = 50
 )
 
-func newNetwork(subnetMgr subnet.Manager, extIface *backend.ExternalInterface, dev *vxlanDevice, v6Dev *vxlanDevice, _ ip.IP4Net, lease *subnet.Lease) (*network, error) {
+func newNetwork(subnetMgr subnet.Manager, extIface *backend.ExternalInterface, dev *vxlanDevice, v6Dev *vxlanDevice, _ ip.IP4Net, lease *subnet.Lease, mtu int) (*network, error) {
 	nw := &network{
 		SimpleNetwork: backend.SimpleNetwork{
 			SubnetLease: lease,
@@ -51,6 +52,7 @@ func newNetwork(subnetMgr subnet.Manager, extIface *backend.ExternalInterface, d
 		subnetMgr: subnetMgr,
 		dev:       dev,
 		v6Dev:     v6Dev,
+		mtu:       mtu,
 	}
 
 	return nw, nil
@@ -81,7 +83,7 @@ func (nw *network) Run(ctx context.Context) {
 }
 
 func (nw *network) MTU() int {
-	return nw.ExtIface.Iface.MTU - encapOverhead
+	return nw.mtu - encapOverhead
 }
 
 type vxlanLeaseAttrs struct {

--- a/pkg/backend/wireguard/wireguard_network.go
+++ b/pkg/backend/wireguard/wireguard_network.go
@@ -49,9 +49,10 @@ type network struct {
 	mode     Mode
 	lease    *subnet.Lease
 	sm       subnet.Manager
+	mtu      int
 }
 
-func newNetwork(sm subnet.Manager, extIface *backend.ExternalInterface, dev, v6Dev *wgDevice, mode Mode, lease *subnet.Lease) (*network, error) {
+func newNetwork(sm subnet.Manager, extIface *backend.ExternalInterface, dev, v6Dev *wgDevice, mode Mode, lease *subnet.Lease, mtu int) (*network, error) {
 	n := &network{
 		dev:      dev,
 		v6Dev:    v6Dev,
@@ -59,6 +60,7 @@ func newNetwork(sm subnet.Manager, extIface *backend.ExternalInterface, dev, v6D
 		mode:     mode,
 		lease:    lease,
 		sm:       sm,
+		mtu:      mtu,
 	}
 
 	return n, nil
@@ -69,7 +71,7 @@ func (n *network) Lease() *subnet.Lease {
 }
 
 func (n *network) MTU() int {
-	return n.extIface.Iface.MTU - overhead
+	return n.mtu - overhead
 }
 
 func (n *network) Run(ctx context.Context) {


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Linked issue #1011 
Added `MTU` config to use inside the backend configuration for `vxlan` and `wireguard` backend.
The MTU configured is the MTU desired for the outgoing traffic the final MTU configured on the network interface will be `MTU - overhead`

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
