### PR TITLE
Fix the bootstrap error when iface uses ip address under dualstack

### DIFF
--- a/pkg/ipmatch/match_test.go
+++ b/pkg/ipmatch/match_test.go
@@ -37,6 +37,7 @@ func TestLookupExtIface(t *testing.T) {
 	execOrFail("sudo", "ip", "addr", "add", "172.16.30.18", "dev", "dummy0")
 	execOrFail("sudo", "ip", "addr", "add", "172.16.31.200", "dev", "dummy0")
 	execOrFail("sudo", "ip", "addr", "add", "172.16.32.100", "dev", "dummy0")
+	execOrFail("sudo", "ip", "addr", "add", "1::6", "dev", "dummy0")
 	execOrFail("sudo", "ip", "link", "set", "dummy0", "up")
 	execOrFail("sudo", "ip", "route", "add", "172.16.32.254", "via", "172.16.32.100", "dev", "dummy0")
 
@@ -102,6 +103,52 @@ func TestLookupExtIface(t *testing.T) {
 		}
 		if backendInterface.IfaceAddr.String() != "172.16.30.18" {
 			t.Fatalf("iface addr not equal, expected=%v actual=%v", "172.16.30.18", backendInterface.IfaceAddr.String())
+		}
+	})
+
+	t.Run("ByIPv4ForDualStack", func(t *testing.T) {
+		backendInterface, err := LookupExtIface("172.16.30.18", "", "", dualStack, PublicIPOpts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("backendInterface=%+v iface=%+v", backendInterface, *backendInterface.Iface)
+
+		if backendInterface.Iface.Name != "dummy0" {
+			t.Fatalf("iface name not equal, expected=%v actual=%v", "dummy0", backendInterface.Iface.Name)
+		}
+		if backendInterface.IfaceAddr.String() != "172.16.30.18" {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "172.16.30.18", backendInterface.IfaceAddr.String())
+		}
+		if backendInterface.IfaceV6Addr.String() != "1::6" {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "1::6", backendInterface.IfaceV6Addr.String())
+		}
+	})
+
+	t.Run("ByIPv6ForDualStack", func(t *testing.T) {
+		backendInterface, err := LookupExtIface("1::6", "", "", dualStack, PublicIPOpts{})
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Logf("backendInterface=%+v iface=%+v", backendInterface, *backendInterface.Iface)
+
+		if backendInterface.Iface.Name != "dummy0" {
+			t.Fatalf("iface name not equal, expected=%v actual=%v", "dummy0", backendInterface.Iface.Name)
+		}
+
+		var isInArray = func(s string, arr []string) bool {
+			for _, str := range arr {
+				if s == str {
+					return true
+				}
+			}
+			return false
+		}
+		expectedIPs := []string{"1.10.100.1", "192.168.200.128", "172.16.30.18", "172.16.31.200", "172.16.32.100"}
+		if !isInArray(backendInterface.IfaceAddr.String(), expectedIPs) {
+			t.Fatalf("iface addr is not in expected array, expected=%v actual=%v", expectedIPs, backendInterface.IfaceAddr.String())
+		}
+		if backendInterface.IfaceV6Addr.String() != "1::6" {
+			t.Fatalf("iface addr not equal, expected=%v actual=%v", "1::6", backendInterface.IfaceV6Addr.String())
 		}
 	})
 


### PR DESCRIPTION
## Description

**[bug fix]** 
The current flannel has the following problems:
When `FLANNELD_IFACE` uses ipv4 address, flannel cannot get ipv6 address on iface;
When `FLANNELD_IFACE` uses ipv6 address, flannel cannot get ipv4 address on iface;

My flannel configuration is as follows:

```
cni-conf.json: |-
    {
      "cniVersion": "1.0.0",
      "name": "cbr0",
      "plugins": [
        {
          "type": "flannel",
          "delegate": {
            "hairpinMode": true,
            "isDefaultGateway": true
          }
        },
        {
          "type": "portmap",
          "capabilities": {
            "portMappings": true
          }
        },
        {
          "type": "firewall"
        }
      ]
    }
  net-conf.json: |-
    {
      "EnableIPv4": true,
      "EnableIPv6": true,
      "Network": "172.16.0.0/16",
      "IPv6Network": "fd00:1234:5678::/64",
      "SubnetLen": 24,
      "IPv6SubnetLen": 80,
      "Backend": {
        "Type": "host-gw"
      }
    }
```

`FLANNELD_IFACE` can work normally with name,

```
export KUBERNETES_SERVICE_HOST=simoncosvm03.xxxswlab.net
export FLANNELD_IFACE=ens32
```

but with ip address, it will start to report an error.

```
export KUBERNETES_SERVICE_HOST=simoncosvm03.xxxswlab.net
export FLANNELD_IFACE=192.168.1.106
```

errors:

```
[root@simonCOSvm01 ~]# kubectl logs -f kube-flannel-ds-amd64-s7596 -n kube-system
Defaulted container "kube-flannel" out of: kube-flannel, install-cni (init)
I0413 05:45:31.754134       7 main.go:204] CLI flags config: {etcdEndpoints:http://127.0.0.1:4001,http://127.0.0.1:2379 etcdPrefix:/coreos.com/network etcdKeyfile: etcdCertfile: etcdCAFile: etcdUsername: etcdPassword: version:false kubeSubnetMgr:true kubeApiUrl: kubeAnnotationPrefix:flannel.alpha.coreos.com kubeConfigFile: iface:[192.168.1.106] ifaceRegex:[] ipMasq:false ifaceCanReach: subnetFile:/run/flannel/subnet.env publicIP: publicIPv6: subnetLeaseRenewMargin:60 healthzIP:0.0.0.0 healthzPort:0 iptablesResyncSeconds:5 iptablesForwardRules:true netConfPath:/etc/kube-flannel/net-conf.json setNodeNetworkUnavailable:true}
W0413 05:45:31.754565       7 client_config.go:617] Neither --kubeconfig nor --master was specified.  Using the inClusterConfig.  This might not work.
I0413 05:45:31.942397       7 kube.go:420] Starting kube subnet manager
I0413 05:45:31.942212       7 kube.go:126] Waiting 10m0s for node controller to sync
I0413 05:45:31.952062       7 kube.go:449] Creating the node lease for IPv6. This is the n.Spec.PodCIDRs: [172.16.0.0/24 fd00:1234:5678::/80]
I0413 05:45:32.944761       7 kube.go:133] Node controller sync successful
I0413 05:45:32.944818       7 main.go:224] Created subnet manager: Kubernetes Subnet Manager - 192.168.1.106
I0413 05:45:32.944836       7 main.go:227] Installing signal handlers
I0413 05:45:32.945254       7 main.go:467] Found network config - Backend type: host-gw
I0413 05:45:32.945376       7 match.go:73] Searching for interface using 192.168.1.106
I0413 05:45:32.947416       7 match.go:259] Using interface with name ens32 and address 192.168.1.106
I0413 05:45:32.947480       7 match.go:281] Defaulting external address to interface address (192.168.1.106)
I0413 05:45:32.947507       7 match.go:294] Defaulting external v6 address to interface address (<nil>)
panic: Address is not an IPv6 address

goroutine 1 [running]:
github.com/flannel-io/flannel/pkg/ip.FromIP6({0x0?, 0x1c52d40?, 0x0?})
        /home/jenkins/agent/workspace/hared-3rd-flannel_support-0.20.x/shared-3rd-flannel/pkg/ip/ip6net.go:35 +0xe9
github.com/flannel-io/flannel/backend/hostgw.(*HostgwBackend).RegisterNetwork(0xc000512180, {0x1c6c068, 0xc000050dc0}, 0x0?, 0xc000295080)
        /home/jenkins/agent/workspace/hared-3rd-flannel_support-0.20.x/shared-3rd-flannel/backend/hostgw/hostgw.go:79 +0x199
main.main()
        /home/jenkins/agent/workspace/hared-3rd-flannel_support-0.20.x/shared-3rd-flannel/main.go:325 +0xcbe
```
     


After fixed, `FLANNELD_IFACE` can use ipv4 or ipv6 normally.

```
export KUBERNETES_SERVICE_HOST=simoncosvm03.xxxswlab.net
export FLANNELD_IFACE=192.168.1.106
```
or
```
export KUBERNETES_SERVICE_HOST=simoncosvm03.xxxswlab.net
export FLANNELD_IFACE=1::6
```

<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [x] Tests           
- [ ] Documentation
- [ ] Release note

test1: **go test**
```
# go test -v -cover -timeout 5m github.com/flannel-io/flannel/pkg/ipmatch
=== RUN   TestLookupExtIface
=== RUN   TestLookupExtIface/ByIfRegexForIPv4
......
......
......
--- PASS: TestLookupExtIface (0.26s)
    --- PASS: TestLookupExtIface/ByIfRegexForIPv4 (0.00s)
    --- PASS: TestLookupExtIface/ByIfRegexForName (0.00s)
    --- PASS: TestLookupExtIface/ByName (0.00s)
    --- PASS: TestLookupExtIface/ByIPv4 (0.00s)
    --- PASS: TestLookupExtIface/ByIPv4ForDualStack (0.00s)
    --- PASS: TestLookupExtIface/ByIPv6ForDualStack (0.00s)
    --- PASS: TestLookupExtIface/ByIfRegexMatchPublicIPv4 (0.00s)
    --- PASS: TestLookupExtIface/ByIfCanReach (0.00s)
PASS
coverage: 51.5% of statements
ok      github.com/flannel-io/flannel/pkg/ipmatch       0.267s  coverage: 51.5% of statements
```

test2: **make test**
```
# make test
# run license-check script
dist/license-check.sh
# Running gofmt...
docker run --rm -e CGO_ENABLED=1 -e GOARCH=amd64 \
......
......
......
Signature ok
subject=/CN=admin/O=system:masters
Getting CA Private Key
Cluster "kubernetes-test-flannel" set.
User "admin" set.
Context "default" created.
Switched to context "default".
        Running test_manifest ... SUCCESS ✓
        Running test_public-ip-overwrite ... SUCCESS ✓
Overall result: SUCCESS ✓
make[1]: Leaving directory `/opt/flannel'
```

## Release Note

```release-note
None required
```
