### PR TITLE
Add IPv6 parameters in the extension backend

### DIFF
--- a/Documentation/extension.md
+++ b/Documentation/extension.md
@@ -14,13 +14,17 @@ This backend has the following configuration
 * `SubnetAddCommand`   (string): Command to run when a subnet is added
     * stdin - The output from `PreStartupCommand` is passed in.
     * The following environment variables are set
-        * SUBNET - The subnet of the remote host that was added.
+        * SUBNET - The ipv4 subnet of the remote host that was added.
+        * IPV6SUBNET - The ipv6 subnet of the remote host that was added.
         * PUBLIC_IP - The public IP of the remote host.
+        * PUBLIC_IPV6 - The public IPv6 of the remote host.
 * `SubnetRemoveCommand`(string): Command to run when a subnet is removed
     * stdin - The output from `PreStartupCommand` is passed in.
       * The following environment variables are set
-          * SUBNET - The subnet of the remote host that was removed.
+          * SUBNET - The ipv4 subnet of the remote host that was removed.
+          * IPV6SUBNET - The ipv6 subnet of the remote host that was removed.
           * PUBLIC_IP - The public IP of the remote host.
+          * PUBLIC_IPV6 - The public IPv6 of the remote host.
 
 All commands are run through the `sh` shell and are run with the same permissions as the flannel daemon.
 

--- a/pkg/backend/extension/extension.go
+++ b/pkg/backend/extension/extension.go
@@ -117,7 +117,9 @@ func (be *ExtensionBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGr
 		cmd_output, err := runCmd([]string{
 			fmt.Sprintf("NETWORK=%s", config.Network),
 			fmt.Sprintf("SUBNET=%s", lease.Subnet),
-			fmt.Sprintf("PUBLIC_IP=%s", attrs.PublicIP)},
+			fmt.Sprintf("IPV6SUBNET=%s", lease.IPv6Subnet),
+			fmt.Sprintf("PUBLIC_IP=%s", attrs.PublicIP),
+			fmt.Sprintf("PUBLIC_IPV6=%s", attrs.PublicIPv6)},
 			"", "sh", "-c", n.postStartupCommand)
 		if err != nil {
 			return nil, fmt.Errorf("failed to run command: %s Err: %v Output: %s", n.postStartupCommand, err, cmd_output)


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

When dualStack support was added to flannel, it was forgotten to provide that support in the extension backend. This PR provides that by passing the lease.IPv6Subnet and attrs.PublicIPv6 parameters

## Todos
- [X] Tests
- [X] Documentation
- [X] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
DualStack support in extension backend
```
