### PR TITLE
Fix: Correct various spelling mistakes in the Documentation project directory.

### DIFF
--- a/Documentation/MultiClusterCIDR/README.md
+++ b/Documentation/MultiClusterCIDR/README.md
@@ -107,7 +107,7 @@ The new nodes will be allocated a `PodCIDR` based on the configured `clustercidr
 flannel will ensure connectivity between all the pods regardless of the subnet in which the pod's IP address has been allocated.
 
 ## Notes on the subnet.env file
-flanneld writes a file (located by default at /run/flannel/subnet.env) that is used by the flannel cni plugin which is called by the kubelet every time a pod is added or removed from the node. This file changes slightly with the new API. The `FLANNEL_NETWORK` and `FLANNEL_IPV6_NETWORK` become lists of CIDRs instead of sigle CIDR entry. They will hold the list of CIDRs declared in the `clustercidr` resource of the API. The file is updated by flanneld every time a new `clustercidr` is created.
+flanneld writes a file (located by default at /run/flannel/subnet.env) that is used by the flannel cni plugin which is called by the kubelet every time a pod is added or removed from the node. This file changes slightly with the new API. The `FLANNEL_NETWORK` and `FLANNEL_IPV6_NETWORK` become lists of CIDRs instead of single CIDR entry. They will hold the list of CIDRs declared in the `clustercidr` resource of the API. The file is updated by flanneld every time a new `clustercidr` is created.
 
 As an example, it could look like this:
 ```bash

--- a/Documentation/MultiClusterCIDR/README.md
+++ b/Documentation/MultiClusterCIDR/README.md
@@ -107,7 +107,7 @@ The new nodes will be allocated a `PodCIDR` based on the configured `clustercidr
 flannel will ensure connectivity between all the pods regardless of the subnet in which the pod's IP address has been allocated.
 
 ## Notes on the subnet.env file
-flanneld writes a file (located by default at /run/flannel/subnet.env) that is used by the flannel cni plugin which is called by the kubelet every time a pod is added or removed from the node. This file changes slightly with the new API. The `FLANNEL_NETWORK` and `FLANNEL_IPV6_NETWORK` become lists of CIDRs instead of single CIDR entry. They will hold the list of CIDRs declared in the `clustercidr` resource of the API. The file is updated by flanneld every time a new `clustercidr` is created.
+flanneld writes a file (located by default at /run/flannel/subnet.env) that is used by the flannel cni plugin which is called by the kubelet every time a pod is added or removed from the node. This file changes slightly with the new API. The `FLANNEL_NETWORK` and `FLANNEL_IPV6_NETWORK` become lists of CIDRs instead of a single CIDR entry. They will hold the list of CIDRs declared in the `clustercidr` resource of the API. The file is updated by flanneld every time a new `clustercidr` is created.
 
 As an example, it could look like this:
 ```bash

--- a/Documentation/backends.md
+++ b/Documentation/backends.md
@@ -26,7 +26,7 @@ Type and options:
 * `MTU` (number): Desired MTU for the outgoing packets if not defined the MTU of the external interface is used.
 * `MacPrefix` (String): Only use on Windows, set to the MAC prefix. Defaults to `0E-2A`.
 
-Starting with Ubuntu 21.10, vxlan support on Raspberry Pi has been moved into a seperate kernel module. 
+Starting with Ubuntu 21.10, vxlan support on Raspberry Pi has been moved into a separate kernel module. 
 ```
 sudo apt install linux-modules-extra-raspi
 ```

--- a/Documentation/building.md
+++ b/Documentation/building.md
@@ -23,7 +23,7 @@ Then you should be able to set the ARCH as above
 
 1. Make sure you have required dependencies installed on your machine.
     * On Ubuntu, run `sudo apt-get install linux-libc-dev golang gcc`. 
-      If the golang version installed is not 1.7 or higher. Download the newest golang and install manully.
+      If the golang version installed is not 1.7 or higher. Download the newest golang and install manually.
       To build the flannel.exe on windows, mingw-w64 is also needed. Run command `sudo apt-get install mingw-w64`
     * On Fedora/Redhat, run `sudo yum install kernel-headers golang gcc glibc-static`.
 2. Git clone the flannel repo. It MUST be placed in your GOPATH under `github.com/flannel-io/flannel`: `cd $GOPATH/src; git clone https://github.com/flannel-io/flannel.git`

--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -8,7 +8,7 @@ NOTE: If `kubeadm` is used, then pass `--pod-network-cidr=10.244.0.0/16` to `kub
 
 The `flannel` manifest defines five things:
 1. A `kube-flannel` with PodSecurity level set to *privileged*. 
-2. A ClusterRole and ClusterRoleBinding for Role Based Acccess Control (RBAC).
+2. A ClusterRole and ClusterRoleBinding for Role Based Access Control (RBAC).
 3. A service account for `flannel` to use.
 4. A ConfigMap containing both a CNI configuration and a `flannel` configuration. The `network` in the `flannel` configuration should match the pod network CIDR. The choice of `backend` is also made here and defaults to VXLAN.
 5. A DaemonSet for every architecture to deploy the `flannel` pod on each Node. The pod has two containers 1) the `flannel` daemon itself, and 2) an initContainer for deploying the CNI configuration to a location that the `kubelet` can read.

--- a/Documentation/troubleshooting.md
+++ b/Documentation/troubleshooting.md
@@ -49,7 +49,7 @@ Depending on the backend being used, flannel may need to run with super user per
 ## Performance
 
 ### Control plane
-Flannel is known to scale to a very large number of hosts. A delay in contacting pods in a newly created host may indicate control plane problems. Flannel doesn't need much CPU or RAM but the first thing to check would be that it has adaquate resources available. Flannel is also reliant on the performance of the datastore, either etcd or the Kubernetes API server. Check that they are performing well.
+Flannel is known to scale to a very large number of hosts. A delay in contacting pods in a newly created host may indicate control plane problems. Flannel doesn't need much CPU or RAM but the first thing to check would be that it has adequate resources available. Flannel is also reliant on the performance of the datastore, either etcd or the Kubernetes API server. Check that they are performing well.
 
 ### Data plane
 Flannel relies on the underlying network so that's the first thing to check if you're seeing poor data plane performance.


### PR DESCRIPTION
These changes correct various spelling errors found in the `Documentation` project directory.

* In `Documentation/MultiClusterCIDR/README.md`, a misspelled word, `sigle`, has been corrected to `single`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/single). 

* In `Documentation/backends.md`, a misspelled word, `seperate`, has been corrected to `separate`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/separate).

* In `Documentation/building.md`, a misspelled word, `manully`, has been corrected to `manually`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/manually).

* In `Documentation/kubernetes.md`, a misspelled word, `Acccess`, has been corrected to `Access`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/access).

* In `Documentation/troubleshooting.md`, a misspelled word, `adaquate`, has been corrected to `adequate`, [following Merriam-Webster's spelling of the word](https://www.merriam-webster.com/dictionary/adequate).