### PR TITLE
feat(helm-chart): command and args configurable

### DIFF
--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -59,10 +59,17 @@ spec:
       containers:
       - name: kube-flannel
         image: {{ .Values.flannel.image.repository }}:{{ .Values.flannel.image.tag }}
-        command:
-        - "/opt/bin/flanneld"
+        {{- if .Values.flannel.command }}
+        command: 
+        {{- range .Values.flannel.command }}
+        - {{ . }}
+        {{- end }}
+        {{- end }}
+        {{- if .Values.flannel.args }}
+        args: 
         {{- range .Values.flannel.args }}
-        - {{ . | quote }}
+        - {{ . }}
+        {{- end }}
         {{- end }}
         resources:
           requests:

--- a/chart/kube-flannel/tests/daemonset_test.yaml
+++ b/chart/kube-flannel/tests/daemonset_test.yaml
@@ -35,6 +35,8 @@ tests:
 
   - it: should have the correct args
     set:
+      flannel.command:
+        - "/opt/bin/flanneld"
       flannel.args:
         - "--ip-masq"
         - "--kube-subnet-mgr"
@@ -43,5 +45,8 @@ tests:
           path: spec.template.spec.containers[0].command
           value:
             - "/opt/bin/flanneld"
+      - equal:
+          path: spec.template.spec.containers[0].args
+          value:
             - "--ip-masq"
             - "--kube-subnet-mgr"

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -13,10 +13,11 @@ flannel:
   image_cni:
     repository: docker.io/flannel/flannel-cni-plugin
     tag: v1.2.0
-  # flannel command arguments
-  args:
-  - "--ip-masq"
-  - "--kube-subnet-mgr"
+
+  # command to execute
+  command: ["/opt/bin/flanneld"]
+  # command arguments
+  args: ["--ip-masq", "--kube-subnet-mgr"]
   # Backend for kube-flannel. Backend should not be changed
   # at runtime. (vxlan, host-gw, wireguard, udp)
   # Documentation at https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md


### PR DESCRIPTION
## Description

This PR adds the ability to the helm chart to configure the command and the args.
The default configuration didn't change. 

fixes #1790


<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [x] Tests
- [x] Documentation - nothing to do
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Helm Chart: command and arguments can now be configured
```
