### PR TITLE
fix: goroutine leak during watch leases (kube)

### DIFF
--- a/pkg/subnet/etcd/subnet_test.go
+++ b/pkg/subnet/etcd/subnet_test.go
@@ -440,7 +440,7 @@ func TestRenewLease(t *testing.T) {
 		t.Fatal("RenewLease failed: ", err)
 	}
 	//we expect the new lease to have an expiration date in exactly 24h
-	acceptableMargin := 5 * time.Second
+	acceptableMargin := 10 * time.Second
 	expectedExpiration := time.Now().Add(subnetTTL).Round(time.Duration(acceptableMargin))
 
 	etcdResp, err := kvApi.Get(ctx, "/coreos.com/network/subnets", etcd.WithPrefix())

--- a/pkg/subnet/kube/kube.go
+++ b/pkg/subnet/kube/kube.go
@@ -480,7 +480,8 @@ func (ksm *kubeSubnetManager) WatchLeases(ctx context.Context, receiver chan []l
 					Events: []lease.Event{event},
 				}}
 		case <-ctx.Done():
-			return context.Canceled
+			close(receiver)
+			return ctx.Err()
 		}
 	}
 }


### PR DESCRIPTION
## Description

In the implementation of Kubernetes API, `leaseWatchChan` did not close correctly after ctx cancellation:

https://github.com/flannel-io/flannel/blob/148b6d6a58deb864519bbc474f4c531a0799e910/pkg/subnet/kube/kube.go#L482-L484

Will cause the following loop to not end:

https://github.com/flannel-io/flannel/blob/148b6d6a58deb864519bbc474f4c531a0799e910/pkg/subnet/subnet.go#L148-L165

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```

Signed-off-by: iiiceoo <iiiceoo@foxmail.com>
