### PR TITLE
Revert "fix: goroutine leak during watch leases (kube)"

### DIFF
--- a/pkg/subnet/etcd/subnet_test.go
+++ b/pkg/subnet/etcd/subnet_test.go
@@ -440,7 +440,7 @@ func TestRenewLease(t *testing.T) {
 		t.Fatal("RenewLease failed: ", err)
 	}
 	//we expect the new lease to have an expiration date in exactly 24h
-	acceptableMargin := 10 * time.Second
+	acceptableMargin := 5 * time.Second
 	expectedExpiration := time.Now().Add(subnetTTL).Round(time.Duration(acceptableMargin))
 
 	etcdResp, err := kvApi.Get(ctx, "/coreos.com/network/subnets", etcd.WithPrefix())

--- a/pkg/subnet/kube/kube.go
+++ b/pkg/subnet/kube/kube.go
@@ -480,8 +480,7 @@ func (ksm *kubeSubnetManager) WatchLeases(ctx context.Context, receiver chan []l
 					Events: []lease.Event{event},
 				}}
 		case <-ctx.Done():
-			close(receiver)
-			return ctx.Err()
+			return context.Canceled
 		}
 	}
 }


### PR DESCRIPTION
Reverts flannel-io/flannel#1799
With the previous PR the socket was closed when it's still used. Further investigations needed to check if it has to be closed.