### PR TITLE
add riscv64 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ dist/flanneld.exe: $(shell find . -type f  -name '*.go')
 
 # This will build flannel natively using golang image
 dist/flanneld-$(ARCH): deps dist/qemu-$(ARCH)-static
-	# valid values for ARCH are [amd64 arm arm64 ppc64le s390x mips64le]
+	# valid values for ARCH are [amd64 arm arm64 ppc64le s390x mips64le riscv64]
 	docker run --rm -e CGO_ENABLED=$(CGO_ENABLED) -e GOARCH=$(ARCH) -e GOCACHE=/go \
 		-u $(shell id -u):$(shell id -g) \
 		-v $(CURDIR)/dist/qemu-$(ARCH)-static:/usr/bin/qemu-$(ARCH)-static \
@@ -144,7 +144,7 @@ dist/flanneld-e2e-$(TAG)-$(ARCH).docker:
 ifneq ($(ARCH),amd64)
 	$(MAKE) dist/qemu-$(ARCH)-static
 endif
-	# valid values for ARCH are [amd64 arm arm64 ppc64le s390x mips64le]
+	# valid values for ARCH are [amd64 arm arm64 ppc64le s390x mips64le riscv64]
 	docker run --rm -e GOARM=$(GOARM) -e CGO_ENABLED=$(CGO_ENABLED) -e GOCACHE=/go \
 		-u $(shell id -u):$(shell id -g) \
 		-v $(CURDIR):/go/src/github.com/flannel-io/flannel:ro \
@@ -157,13 +157,14 @@ endif
 
 # Make a release after creating a tag
 # To build cross platform Docker images, the qemu-static binaries are needed. On ubuntu "apt-get install  qemu-user-static"
-release: tar.gz dist/qemu-s390x-static dist/qemu-ppc64le-static dist/qemu-arm64-static dist/qemu-arm-static dist/qemu-mips64le-static release-chart release-helm #release-tests
+release: tar.gz dist/qemu-s390x-static dist/qemu-ppc64le-static dist/qemu-arm64-static dist/qemu-arm-static dist/qemu-mips64le-static dist/qemu-riscv64-static release-chart release-helm #release-tests
 	ARCH=amd64 make dist/flanneld-$(TAG)-amd64.docker
 	ARCH=arm make dist/flanneld-$(TAG)-arm.docker
 	ARCH=arm64 make dist/flanneld-$(TAG)-arm64.docker
 	ARCH=ppc64le make dist/flanneld-$(TAG)-ppc64le.docker
 	ARCH=s390x make dist/flanneld-$(TAG)-s390x.docker
 	ARCH=mips64le make dist/flanneld-$(TAG)-mips64le.docker
+	ARCH=riscv64 make dist/flanneld-$(TAG)-riscv64.docker
 	@echo "Everything should be built for $(TAG)"
 	@echo "Add all flanneld-* and *.tar.gz files from dist/ to the Github release"
 	@echo "Use make docker-push-all to push the images to a registry"
@@ -193,7 +194,7 @@ dist/qemu-%-static:
 		wget -O dist/$(@F) https://github.com/multiarch/qemu-user-static/releases/download/$(QEMU_VERSION)/$(@F); \
 	fi 
 
-## Build a .tar.gz for the amd64 ppc64le arm arm64 mips64le flanneld binary
+## Build a .tar.gz for the amd64 ppc64le arm arm64 mips64le riscv64 flanneld binary
 tar.gz:
 	ARCH=amd64 make dist/flanneld-amd64
 	tar --transform='flags=r;s|-amd64||' -zcvf dist/flannel-$(TAG)-linux-amd64.tar.gz -C dist flanneld-amd64 mk-docker-opts.sh ../README.md
@@ -216,6 +217,9 @@ tar.gz:
 	ARCH=mips64le make dist/flanneld-mips64le
 	tar --transform='flags=r;s|-mips64le||' -zcvf dist/flannel-$(TAG)-linux-mips64le.tar.gz -C dist flanneld-mips64le mk-docker-opts.sh ../README.md
 	tar -tvf dist/flannel-$(TAG)-linux-mips64le.tar.gz
+	ARCH=riscv64 make dist/flanneld-riscv64
+	tar --transform='flags=r;s|-riscv64||' -zcvf dist/flannel-$(TAG)-linux-riscv64.tar.gz -C dist flanneld-riscv64 mk-docker-opts.sh ../README.md
+	tar -tvf dist/flannel-$(TAG)-linux-riscv64.tar.gz
 
 release-tests: release-etcd-tests release-k8s-tests
 
@@ -251,6 +255,7 @@ docker-push-all:
 	ARCH=ppc64le make docker-push docker-manifest-amend
 	ARCH=s390x make docker-push docker-manifest-amend
 	ARCH=mips64le make docker-push docker-manifest-amend
+	ARCH=riscv64 make docker-push docker-manifest-amend
 	make docker-manifest-push
 
 flannel-git:
@@ -260,6 +265,7 @@ flannel-git:
 	ARCH=ppc64le REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-ppc64le.docker docker-push docker-manifest-amend
 	ARCH=s390x REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-s390x.docker docker-push docker-manifest-amend
 	ARCH=mips64le REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-mips64le.docker docker-push docker-manifest-amend
+	ARCH=riscv64 REGISTRY=quay.io/coreos/flannel-git make clean dist/flanneld-$(TAG)-riscv64.docker docker-push docker-manifest-amend
 	REGISTRY=quay.io/coreos/flannel-git make docker-manifest-push
 
 install:

--- a/images/Dockerfile.riscv64
+++ b/images/Dockerfile.riscv64
@@ -1,0 +1,15 @@
+FROM riscv64/alpine:edge
+
+ENV FLANNEL_ARCH=riscv64
+
+ADD dist/qemu-$FLANNEL_ARCH-static /usr/bin/qemu-$FLANNEL_ARCH-static
+RUN apk update && apk upgrade
+RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan && update-ca-certificates
+RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
+COPY dist/flanneld-$FLANNEL_ARCH /opt/bin/flanneld
+COPY dist/mk-docker-opts.sh /opt/bin/
+COPY dist/iptables-wrapper-installer.sh /
+RUN /iptables-wrapper-installer.sh --no-sanity-check
+
+ENTRYPOINT ["/opt/bin/flanneld"]
+


### PR DESCRIPTION
## Description
it is used to build flanneld and docker image in riscv64.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
None required
