### PR TITLE
Helm chart: Quote wireguard psk to fix config errors

### DIFF
--- a/chart/kube-flannel/templates/config.yaml
+++ b/chart/kube-flannel/templates/config.yaml
@@ -67,7 +67,7 @@ data:
         "ListenPortV6": {{ .Values.flannel.backendPortv6 }},
 {{- end }}
 {{- if .Values.flannel.psk }}
-        "PSK": {{ .Values.flannel.psk }},
+        "PSK": {{ .Values.flannel.psk | quote }},
 {{- end }}
 {{- if .Values.flannel.mtu }}
         "MTU": {{ .Values.flannel.mtu }},


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

When using the helm chart with a wireguard psk, the value is not quoted inside `net-conf.json`.
This results in the SubnetManager config parse to fail.

## Steps to reproduce

```
kubectl create ns kube-flannel
kubectl label --overwrite ns kube-flannel pod-security.kubernetes.io/enforce=privileged
helm repo add flannel https://flannel-io.github.io/flannel/
helm repo update
helm install flannel --set podCidr="10.244.0.0/16" --set flannel.backend="wireguard" --set flannel.psk="SQrrIYA1R4A/zlTkJXP3WWE3Sk+20YJ7w946IGQto/o=" --namespace kube-flannel flannel/flannel
```

`kubectl -n kube-flannel logs pods/kube-flannel-ds-l28qk`

```
[..]
Failed to create SubnetManager: error parsing subnet config: invalid character 'S' after object key:value pair
```
The resulting config is

```
[..]
  net-conf.json: |
    {
      "Network": "10.244.0.0/16",
      "Backend": {
        "PSK": SQrrIYA1R4A/zlTkJXP3WWE3Sk+20YJ7w946IGQto/o=,
        "Type": "wireguard"
      }
    }
```

Quoting the value fixes this issue.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
