### PR TITLE
feat: added persistent-mac option

### DIFF
--- a/pkg/backend/vxlan/device.go
+++ b/pkg/backend/vxlan/device.go
@@ -38,6 +38,7 @@ type vxlanDeviceAttrs struct {
 	vtepPort  int
 	gbp       bool
 	learning  bool
+	hwAddr    net.HardwareAddr
 }
 
 type vxlanDevice struct {
@@ -46,9 +47,13 @@ type vxlanDevice struct {
 }
 
 func newVXLANDevice(devAttrs *vxlanDeviceAttrs) (*vxlanDevice, error) {
-	hardwareAddr, err := mac.NewHardwareAddr()
-	if err != nil {
-		return nil, err
+	var err error
+	hardwareAddr := devAttrs.hwAddr
+	if devAttrs.hwAddr == nil {
+		hardwareAddr, err = mac.NewHardwareAddr()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	link := &netlink.Vxlan{

--- a/pkg/subnet/etcd/local_manager.go
+++ b/pkg/subnet/etcd/local_manager.go
@@ -79,6 +79,10 @@ func newLocalManager(r Registry, prevSubnet ip.IP4Net, prevIPv6Subnet ip.IP6Net,
 	}
 }
 
+func (m *LocalManager) GetStoredMacAddress() string {
+	return ""
+}
+
 func (m *LocalManager) GetNetworkConfig(ctx context.Context) (*subnet.Config, error) {
 	cfg, err := m.registry.getNetworkConfig(ctx)
 	if err != nil {

--- a/pkg/subnet/kube/kube.go
+++ b/pkg/subnet/kube/kube.go
@@ -21,6 +21,7 @@ import (
 	"net"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -65,6 +66,7 @@ type kubeSubnetManager struct {
 	enableIPv4                bool
 	enableIPv6                bool
 	annotations               annotations
+	annotationPrefix          string
 	client                    clientset.Interface
 	nodeName                  string
 	nodeStore                 listers.NodeLister
@@ -160,6 +162,7 @@ func NewSubnetManager(ctx context.Context, apiUrl, kubeconfig, prefix, netConfPa
 func newKubeSubnetManager(ctx context.Context, c clientset.Interface, sc *subnet.Config, nodeName, prefix string, useMultiClusterCidr bool) (*kubeSubnetManager, error) {
 	var err error
 	var ksm kubeSubnetManager
+	ksm.annotationPrefix = prefix
 	ksm.annotations, err = newAnnotations(prefix)
 	if err != nil {
 		return nil, err
@@ -633,4 +636,30 @@ func (m *kubeSubnetManager) HandleSubnetFile(path string, config *subnet.Config,
 		mtu:    mtu,
 	}
 	return subnet.WriteSubnetFile(path, config, ipMasq, sn, ipv6sn, mtu)
+}
+
+// GetStoredMacAddress reads MAC address from node annotations when flannel restarts
+func (ksm *kubeSubnetManager) GetStoredMacAddress() string {
+	// get mac info from Name func.
+	node, err := ksm.client.CoreV1().Nodes().Get(context.TODO(), ksm.nodeName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to get node for backend data: %v", err)
+		return ""
+	}
+
+	// node backend data format: `{"VNI":1,"VtepMAC":"12:c6:65:89:b4:e3"}`
+	// and we will return only mac addr str like 12:c6:65:89:b4:e3
+	if node != nil && node.Annotations != nil {
+		log.Infof("List of node(%s) annotations: %#+v", ksm.nodeName, node.Annotations)
+		backendData, ok := node.Annotations[fmt.Sprintf("%s/backend-data", ksm.annotationPrefix)]
+		if ok {
+			macStr := strings.Trim(backendData, "\"}")
+			macInfoSlice := strings.Split(macStr, ":\"")
+			if len(macInfoSlice) == 2 {
+				return macInfoSlice[1]
+			}
+		}
+	}
+
+	return ""
 }

--- a/pkg/subnet/subnet.go
+++ b/pkg/subnet/subnet.go
@@ -123,6 +123,7 @@ type Manager interface {
 	WatchLeases(ctx context.Context, receiver chan []lease.LeaseWatchResult) error
 	CompleteLease(ctx context.Context, lease *lease.Lease, wg *sync.WaitGroup) error
 
+	GetStoredMacAddress() string
 	Name() string
 }
 


### PR DESCRIPTION
## Description
fixes #1828 

<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

New feature: flag `persistent-mac` that reads the nodes annotation during startup and spins up the flannel.1 interface with the same MAC address. This can be useful when a reboot of the node happened but the old setup needs to be restored.

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
The MAC address of the flannel interface is now persistent beyond restarts
```
