### PR TITLE
vxlan vni should not be type uint16

### DIFF
--- a/pkg/backend/vxlan/vxlan.go
+++ b/pkg/backend/vxlan/vxlan.go
@@ -89,7 +89,7 @@ func New(sm subnet.Manager, extIface *backend.ExternalInterface) (backend.Backen
 	return backend, nil
 }
 
-func newSubnetAttrs(publicIP net.IP, publicIPv6 net.IP, vnid uint16, dev, v6Dev *vxlanDevice) (*lease.LeaseAttrs, error) {
+func newSubnetAttrs(publicIP net.IP, publicIPv6 net.IP, vnid uint32, dev, v6Dev *vxlanDevice) (*lease.LeaseAttrs, error) {
 	leaseAttrs := &lease.LeaseAttrs{
 		BackendType: "vxlan",
 	}
@@ -178,7 +178,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGroup,
 		v6Dev.directRouting = cfg.DirectRouting
 	}
 
-	subnetAttrs, err := newSubnetAttrs(be.extIface.ExtAddr, be.extIface.ExtV6Addr, uint16(cfg.VNI), dev, v6Dev)
+	subnetAttrs, err := newSubnetAttrs(be.extIface.ExtAddr, be.extIface.ExtV6Addr, uint32(cfg.VNI), dev, v6Dev)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/backend/vxlan/vxlan_network.go
+++ b/pkg/backend/vxlan/vxlan_network.go
@@ -88,7 +88,7 @@ func (nw *network) MTU() int {
 }
 
 type vxlanLeaseAttrs struct {
-	VNI     uint16
+	VNI     uint32
 	VtepMAC hardwareAddr
 }
 


### PR DESCRIPTION
## Description
according to https://datatracker.ietf.org/doc/html/rfc7348, vxlan cni is 24-bit. we should not use uint16 to hold it.

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note