### PR TITLE
chart: add possibility for defining image pull secrets in daemonset

### DIFF
--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -107,3 +107,6 @@ spec:
         hostPath:
           path: /run/xtables.lock
           type: FileOrCreate
+      {{- if .Values.global.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.global.imagePullSecrets | nindent 6 }}
+      {{- end }}

--- a/chart/kube-flannel/tests/daemonset_test.yaml
+++ b/chart/kube-flannel/tests/daemonset_test.yaml
@@ -45,3 +45,13 @@ tests:
             - "/opt/bin/flanneld"
             - "--ip-masq"
             - "--kube-subnet-mgr"
+
+  - it: should have the correct image pull secrets
+    set:
+      global.imagePullSecrets:
+        - name: "a-test-secret"
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets
+          value:
+            - name: "a-test-secret"

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -1,4 +1,7 @@
 ---
+global:
+  imagePullSecrets:
+# - name: "a-secret-name"
 
 # The IPv4 cidr pool to create on startup if none exists. Pod IPs will be
 # chosen from this range.


### PR DESCRIPTION
when users overwrite image repository, image pull secrets may be required to have access
