### PR TITLE
Fix bug in chart config template

### DIFF
--- a/chart/kube-flannel/templates/config.yaml
+++ b/chart/kube-flannel/templates/config.yaml
@@ -56,7 +56,7 @@ data:
         "MTU": {{ .Values.flannel.mtu }},
 {{- end }}
 {{- if .Values.flannel.macPrefix }}
-        "MacPrefix": {{ .Values.flannel.macPrefix }},
+        "MacPrefix": {{ .Values.flannel.macPrefix | quote }},
 {{- end }}
         "Type": {{ .Values.flannel.backend | quote }}
 {{- else if eq .Values.flannel.backend "wireguard" }}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

When installing flannel from the chart, if we don't quote that value, we get the error:
```
E0124 10:50:40.343650       1 main.go:226] Failed to create SubnetManager: error parsing subnet config: invalid character 'A' after object key:value pair
```
Because the config is:
```
  net-conf.json: |
    {
      "Network": "10.42.0.0/16",
      "Backend": {
        "VNI": 1,
        "MTU": 1500,
        "MacPrefix": 0E-2A,
        "Type": "vxlan"
      }
    }
```
i.e. the MacPrefix requires quotes

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix bug in chart config template
```
