### PR TITLE
Simplify trafficmanager interface

### DIFF
--- a/pkg/subnet/config.go
+++ b/pkg/subnet/config.go
@@ -303,3 +303,19 @@ func (c *Config) HasIPv6Networks() bool {
 		return false
 	}
 }
+
+func (c *Config) GetNetworks() []ip.IP4Net {
+	if len(c.Networks) > 0 {
+		return c.Networks
+	} else {
+		return []ip.IP4Net{c.Network}
+	}
+}
+
+func (c *Config) GeIPv6tNetworks() []ip.IP6Net {
+	if len(c.Networks) > 0 {
+		return c.IPv6Networks
+	} else {
+		return []ip.IP6Net{c.IPv6Network}
+	}
+}

--- a/pkg/trafficmngr/iptables/iptables_test.go
+++ b/pkg/trafficmngr/iptables/iptables_test.go
@@ -121,7 +121,7 @@ func TestDeleteRules(t *testing.T) {
 	ipt := &MockIPTables{t: t}
 	iptr := &MockIPTablesRestore{t: t}
 	iptm := IPTablesManager{}
-	baseRules := iptm.MasqRules([]ip.IP4Net{{
+	baseRules := iptm.masqRules([]ip.IP4Net{{
 		IP:        ip.MustParseIP4("10.0.1.0"),
 		PrefixLen: 16,
 	}}, testingLease())

--- a/pkg/trafficmngr/iptables/iptables_windows.go
+++ b/pkg/trafficmngr/iptables/iptables_windows.go
@@ -17,7 +17,6 @@ package iptables
 import (
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/pkg/lease"
-	"github.com/flannel-io/flannel/pkg/trafficmngr"
 )
 
 type IPTablesManager struct{}
@@ -30,21 +29,14 @@ type IPTables interface {
 	Exists(table string, chain string, rulespec ...string) (bool, error)
 }
 
-func (iptm IPTablesManager) CreateIP4Chain(table, chain string) { return }
-func (iptm IPTablesManager) CreateIP6Chain(table, chain string) { return }
-func (iptm IPTablesManager) MasqRules(cluster_cidrs []ip.IP4Net, lease *lease.Lease) []trafficmngr.IPTablesRule {
+func (iptm IPTablesManager) SetupAndEnsureForwardRules(flannelIPv4Network, flannelIPv6Network string, resyncPeriod int) {
+}
+
+func (iptm IPTablesManager) SetupAndEnsureMasqRules(flannelIPv4Net, prevSubnet ip.IP4Net,
+	prevNetworks []ip.IP4Net,
+	currentlease *lease.Lease,
+	flannelIPv6Net, prevIPv6Subnet ip.IP6Net,
+	prevIPv6Networks []ip.IP6Net,
+	resyncPeriod int) error {
 	return nil
 }
-func (iptm IPTablesManager) ForwardRules(flannelNetwork string) []trafficmngr.IPTablesRule {
-	return nil
-}
-func teardownIPTables(ipt IPTables, rules []trafficmngr.IPTablesRule) {}
-func (iptm IPTablesManager) SetupAndEnsureIP4Tables(getRules func() []trafficmngr.IPTablesRule, resyncPeriod int) {
-}
-func (iptm IPTablesManager) SetupAndEnsureIP6Tables(getRules func() []trafficmngr.IPTablesRule, resyncPeriod int) {
-}
-func (iptm IPTablesManager) MasqIP6Rules(cluster_cidrs []ip.IP6Net, lease *lease.Lease) []trafficmngr.IPTablesRule {
-	return nil
-}
-func (iptm IPTablesManager) DeleteIP4Tables(rules []trafficmngr.IPTablesRule) error { return nil }
-func (iptm IPTablesManager) DeleteIP6Tables(rules []trafficmngr.IPTablesRule) error { return nil }


### PR DESCRIPTION
## Description
There are now only two methods:
- SetupAndEnsureForwardRules
- SetupAndEnsureMasqRules
This will help hide the implementation details that are specific to
iptables and nftables.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
