### PR TITLE
SubnetManager should use the main context

### DIFF
--- a/pkg/backend/vxlan/vxlan.go
+++ b/pkg/backend/vxlan/vxlan.go
@@ -146,7 +146,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGroup,
 	// When flannel is restarted, it will get the MAC address from the node annotations to set flannel.1 MAC address
 	var hwAddr net.HardwareAddr
 
-	macStr := be.subnetMgr.GetStoredMacAddress()
+	macStr := be.subnetMgr.GetStoredMacAddress(ctx)
 	if macStr != "" {
 		hwAddr, err = net.ParseMAC(macStr)
 		if err != nil {

--- a/pkg/subnet/etcd/local_manager.go
+++ b/pkg/subnet/etcd/local_manager.go
@@ -79,7 +79,7 @@ func newLocalManager(r Registry, prevSubnet ip.IP4Net, prevIPv6Subnet ip.IP6Net,
 	}
 }
 
-func (m *LocalManager) GetStoredMacAddress() string {
+func (m *LocalManager) GetStoredMacAddress(ctx context.Context) string {
 	return ""
 }
 

--- a/pkg/subnet/kube/kube.go
+++ b/pkg/subnet/kube/kube.go
@@ -134,7 +134,7 @@ func NewSubnetManager(ctx context.Context, apiUrl, kubeconfig, prefix, netConfPa
 	if sm.disableNodeInformer {
 		log.Infof("Node controller skips sync")
 	} else {
-		go sm.Run(context.Background())
+		go sm.Run(ctx)
 
 		log.Infof("Waiting %s for node controller to sync", nodeControllerSyncTimeout)
 		err = wait.Poll(time.Second, nodeControllerSyncTimeout, func() (bool, error) {
@@ -607,9 +607,9 @@ func (m *kubeSubnetManager) HandleSubnetFile(path string, config *subnet.Config,
 }
 
 // GetStoredMacAddress reads MAC address from node annotations when flannel restarts
-func (ksm *kubeSubnetManager) GetStoredMacAddress() string {
+func (ksm *kubeSubnetManager) GetStoredMacAddress(ctx context.Context) string {
 	// get mac info from Name func.
-	node, err := ksm.client.CoreV1().Nodes().Get(context.TODO(), ksm.nodeName, metav1.GetOptions{})
+	node, err := ksm.client.CoreV1().Nodes().Get(ctx, ksm.nodeName, metav1.GetOptions{})
 	if err != nil {
 		log.Errorf("Failed to get node for backend data: %v", err)
 		return ""

--- a/pkg/subnet/subnet.go
+++ b/pkg/subnet/subnet.go
@@ -123,7 +123,7 @@ type Manager interface {
 	WatchLeases(ctx context.Context, receiver chan []lease.LeaseWatchResult) error
 	CompleteLease(ctx context.Context, lease *lease.Lease, wg *sync.WaitGroup) error
 
-	GetStoredMacAddress() string
+	GetStoredMacAddress(ctx context.Context) string
 	Name() string
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

For some unknown reason, subnetManager was using a different context than the main one, thus the `cancel()` method to clean up flannel resources will never work in this case.

This PR fixes that and subnetManager will use the main context

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
