### PR TITLE
Use manual test to ensure iptables-* binaries are present

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -33,6 +33,9 @@ COPY --from=build /build/dist/flanneld /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
 COPY --from=build /iptables-wrapper/iptables-wrapper-installer.sh /
 COPY --from=build /iptables-wrapper/bin/iptables-wrapper /
+# check manually that iptables-legacy and iptables-nft are present since
+# iptables-wrapper-installer.sh sanity check doesn't work for multi-arch build
+RUN which iptables-legacy && which iptables-nft
 RUN /iptables-wrapper-installer.sh --no-sanity-check
 
 


### PR DESCRIPTION
The sanity check in `iptables-wrapper-installer.sh` is important in case a version of the base image for some arch doesn't include all the needed iptables-related files.
But it fails for multi-arch build so we have to use a manual test.





## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
