### PR TITLE
Remove net-tools package from the image

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -27,7 +27,7 @@ RUN export GOOS=$(xx-info os) &&\
 
 FROM alpine:20231219
 RUN apk update && apk upgrade
-RUN apk add --no-cache iproute2 net-tools ca-certificates iptables strongswan iptables-legacy && update-ca-certificates
+RUN apk add --no-cache iproute2 ca-certificates iptables strongswan iptables-legacy && update-ca-certificates
 RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY --from=build /build/dist/flanneld /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

The net-tools package is pretty old and iproute2 should be enough. The net-tools package provides;
```
arp, hostname, ifconfig, ipmaddr, iptunnel, mii-tool, nameif, netstat, plipconfig, rarp, route und slattach
```
and we are not using them. The only one we use is `arp` in dist/extension-vxlan but we are consuming vxlan via its own backend. This is probably why this package was used

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Removed net-tools package from the image 
```
