### PR TITLE
Add extra check before acquiring lease

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ else
 endif
 
 # Go version to use for builds
-GO_VERSION=1.20
+GO_VERSION=1.21
 
 # K8s version used for Makefile helpers
 K8S_VERSION=1.24.6

--- a/pkg/lease/lease.go
+++ b/pkg/lease/lease.go
@@ -45,7 +45,7 @@ type LeaseAttrs struct {
 	BackendV6Data json.RawMessage `json:",omitempty"`
 }
 
-// Lease includes information about the lease 
+// Lease includes information about the lease
 type Lease struct {
 	EnableIPv4 bool
 	EnableIPv6 bool
@@ -67,7 +67,7 @@ type LeaseWatchResult struct {
 }
 
 type LeaseWatcher struct {
-	OwnLease *Lease //Lease with the subnet of the local node
+	OwnLease *Lease  //Lease with the subnet of the local node
 	Leases   []Lease //Leases with subnets from other nodes
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

In certain windows environments, the host network is not ready by the time we acquire the lease, which makes flannel crash. This PR makes an additional check before acquiring the lease, so that we are sure the network is ready by the time we try acquiring the lease.

Apart from that, the PR:
* adds a bit more context to the errors in windows
* updates test golang version to 1.21 (in sync with go.mod)
* Fixed gofmt problems in lease.go

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Check network is ready before acquiring lease in windows
```
