### PR TITLE
Added configuration for pulic-ip through node annotation

### DIFF
--- a/Documentation/kubernetes.md
+++ b/Documentation/kubernetes.md
@@ -31,7 +31,8 @@ If you want to deploy `flannel` securely in a shared namespace or want more fine
 Other options include [Kyverno](https://kyverno.io/policies/pod-security/) and [OPA Gatekeeper](https://github.com/open-policy-agent/gatekeeper).
 # Annotations
 
-*  `flannel.alpha.coreos.com/public-ip-overwrite`: Allows to overwrite the public IP of a node. Useful if the public IP can not determined from the node, e.G. because it is behind a NAT. It can be automatically set to a nodes `ExternalIP` using the [flannel-node-annotator](https://github.com/alvaroaleman/flannel-node-annotator)
+*  `flannel.alpha.coreos.com/public-ip`, `flannel.alpha.coreos.com/public-ipv6`: Define the used public IP of the node. If configured when Flannel starts it'll be used as the `public-ip` and `public-ipv6` flag.
+*  `flannel.alpha.coreos.com/public-ip-overwrite`, `flannel.alpha.coreos.com/public-ipv6-overwrite`: Allows to overwrite the public IP of a node. Useful if the public IP can not determined from the node, e.G. because it is behind a NAT. It can be automatically set to a nodes `ExternalIP` using the [flannel-node-annotator](https://github.com/alvaroaleman/flannel-node-annotator)
 
 ## Older versions of Kubernetes
 

--- a/main.go
+++ b/main.go
@@ -262,6 +262,15 @@ func main() {
 
 	// Work out which interface to use
 	var extIface *backend.ExternalInterface
+
+	annotatedPublicIP, annotatedPublicIPv6 := sm.GetStoredPublicIP(ctx)
+	if annotatedPublicIP != "" {
+		opts.publicIP = annotatedPublicIP
+	}
+	if annotatedPublicIPv6 != "" {
+		opts.publicIPv6 = annotatedPublicIPv6
+	}
+
 	optsPublicIP := ipmatch.PublicIPOpts{
 		PublicIP:   opts.publicIP,
 		PublicIPv6: opts.publicIPv6,

--- a/pkg/subnet/etcd/local_manager.go
+++ b/pkg/subnet/etcd/local_manager.go
@@ -83,6 +83,10 @@ func (m *LocalManager) GetStoredMacAddresses(ctx context.Context) (string, strin
 	return "", ""
 }
 
+func (m *LocalManager) GetStoredPublicIP(ctx context.Context) (string, string) {
+	return "", ""
+}
+
 func (m *LocalManager) GetNetworkConfig(ctx context.Context) (*subnet.Config, error) {
 	cfg, err := m.registry.getNetworkConfig(ctx)
 	if err != nil {

--- a/pkg/subnet/kube/kube.go
+++ b/pkg/subnet/kube/kube.go
@@ -641,3 +641,22 @@ func (ksm *kubeSubnetManager) GetStoredMacAddresses(ctx context.Context) (string
 
 	return "", ""
 }
+
+// GetStoredPublicIP reads if there are any public IP configured as annotation when flannel starts
+func (ksm *kubeSubnetManager) GetStoredPublicIP(ctx context.Context) (string, string) {
+	// get mac info from Name func.
+	node, err := ksm.client.CoreV1().Nodes().Get(ctx, ksm.nodeName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to get node for backend data: %v", err)
+		return "", ""
+	}
+
+	if node != nil && node.Annotations != nil {
+		log.Infof("List of node(%s) annotations: %#+v", ksm.nodeName, node.Annotations)
+		publicIP := node.Annotations[ksm.annotations.BackendPublicIP]
+		publicIPv6 := node.Annotations[ksm.annotations.BackendPublicIPv6]
+		return publicIP, publicIPv6
+	}
+
+	return "", ""
+}

--- a/pkg/subnet/subnet.go
+++ b/pkg/subnet/subnet.go
@@ -115,6 +115,7 @@ type Manager interface {
 	CompleteLease(ctx context.Context, lease *lease.Lease, wg *sync.WaitGroup) error
 
 	GetStoredMacAddresses(ctx context.Context) (string, string)
+	GetStoredPublicIP(ctx context.Context) (string, string)
 	Name() string
 }
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
Related to #1813 with this PR when Flannel starts it checks the node annotation and if `public-ip` or `public-ipv6`  are defined it'll use the one defined to select the network interface.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
