### PR TITLE
extension/vxlan: remove arp commands from vxlan examples

### DIFF
--- a/Documentation/extension.md
+++ b/Documentation/extension.md
@@ -59,7 +59,7 @@ An example
     "Type": "extension",
     "PreStartupCommand": "export VNI=1; export IF_NAME=flannel-vxlan; ip link del $IF_NAME 2>/dev/null; ip link add $IF_NAME type vxlan id $VNI dstport 8472 && cat /sys/class/net/$IF_NAME/address",
     "PostStartupCommand": "export IF_NAME=flannel-vxlan; export SUBNET_IP=`echo $SUBNET | cut -d'/' -f 1`; ip addr add $SUBNET_IP/32 dev $IF_NAME && ip link set $IF_NAME up",
-    "SubnetAddCommand": "export SUBNET_IP=`echo $SUBNET | cut -d'/' -f 1`; export IF_NAME=flannel-vxlan; read VTEP; ip route add $SUBNET nexthop via $SUBNET_IP dev $IF_NAME onlink && arp -s $SUBNET_IP $VTEP dev $IF_NAME && bridge fdb add $VTEP dev $IF_NAME self dst $PUBLIC_IP"
+    "SubnetAddCommand": "export SUBNET_IP=`echo $SUBNET | cut -d'/' -f 1`; export IF_NAME=flannel-vxlan; read VTEP; ip route add $SUBNET nexthop via $SUBNET_IP dev $IF_NAME onlink && ip neigh replace $SUBNET_IP dev $IF_NAME lladdr $VTEP && bridge fdb add $VTEP dev $IF_NAME self dst $PUBLIC_IP"
   }
 }
 ```

--- a/dist/extension-vxlan
+++ b/dist/extension-vxlan
@@ -5,6 +5,6 @@
     "PreStartupCommand": "export VNI=1; export IF_NAME=flannel-vxlan; ip link del $IF_NAME 2>/dev/null; ip link add $IF_NAME type vxlan id $VNI dstport 8472 nolearning && ip link set mtu 1450 dev $IF_NAME && cat /sys/class/net/$IF_NAME/address",
     "PostStartupCommand": "export IF_NAME=flannel-vxlan; export SUBNET_IP=`echo $SUBNET | cut -d'/' -f 1`; ip addr add $SUBNET_IP/32 dev $IF_NAME && ip link set $IF_NAME up",
     "ShutdownCommand": "export IF_NAME=flannel-vxlan; ip link del $IF_NAME",
-    "SubnetAddCommand": "export SUBNET_IP=`echo $SUBNET | cut -d'/' -f 1`; export IF_NAME=flannel-vxlan; read VTEP; ip route add $SUBNET nexthop via $SUBNET_IP dev $IF_NAME onlink && arp -s $SUBNET_IP $VTEP dev $IF_NAME && bridge fdb add $VTEP dev $IF_NAME self dst $PUBLIC_IP"
+    "SubnetAddCommand": "export SUBNET_IP=`echo $SUBNET | cut -d'/' -f 1`; export IF_NAME=flannel-vxlan; read VTEP; ip route add $SUBNET nexthop via $SUBNET_IP dev $IF_NAME onlink && ip neigh replace $SUBNET_IP dev $IF_NAME lladdr $VTEP && bridge fdb add $VTEP dev $IF_NAME self dst $PUBLIC_IP"
   }
 }


### PR DESCRIPTION
Commit 645c8a126bf (Remove net-tools since it's an old package that we are not using) was incomplete.  The vxlan examples still use the arp command.  This commit updates those to use `ip neigh replace' instead.

```release-note
None required
```
