### PR TITLE
wireguard backend: avoid error message if route already exists

### DIFF
--- a/pkg/backend/wireguard/device.go
+++ b/pkg/backend/wireguard/device.go
@@ -233,7 +233,7 @@ func (dev *wgDevice) addRoute(dst *net.IPNet) error {
 		Dst:       dst,
 	}
 
-	err := netlink.RouteAdd(&route)
+	err := netlink.RouteReplace(&route)
 	if err != nil {
 		return fmt.Errorf("failed to add route %s: %w", dev.attrs.name, err)
 	}


### PR DESCRIPTION
While processing node add events, flannel-wg routes are added irrespective of whether they already exist. This causes an error message for each wg peer. This might be misleading since there is actually no problem. By add or replacing the route, this can be avoided.

Fixes #1963

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [?] Tests
- [n/a] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Avoid error message if wireguard route already exists on node.
```
