### PR TITLE
Fixed IPv6 0 initialization

### DIFF
--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"math/big"
 	"net"
 	"net/http"
 	"os"
@@ -502,10 +503,10 @@ func ReadCIDRFromSubnetFile(path string, CIDRKey string) ip.IP4Net {
 	prevCIDRs := ReadCIDRsFromSubnetFile(path, CIDRKey)
 	if len(prevCIDRs) == 0 {
 		log.Warningf("no subnet found for key: %s in file: %s", CIDRKey, path)
-		return ip.IP4Net{}
+		return ip.IP4Net{IP: 0, PrefixLen: 0}
 	} else if len(prevCIDRs) > 1 {
 		log.Errorf("error reading subnet: more than 1 entry found for key: %s in file %s: ", CIDRKey, path)
-		return ip.IP4Net{}
+		return ip.IP4Net{IP: 0, PrefixLen: 0}
 	} else {
 		return prevCIDRs[0]
 	}
@@ -537,10 +538,10 @@ func ReadIP6CIDRFromSubnetFile(path string, CIDRKey string) ip.IP6Net {
 	prevCIDRs := ReadIP6CIDRsFromSubnetFile(path, CIDRKey)
 	if len(prevCIDRs) == 0 {
 		log.Warningf("no subnet found for key: %s in file: %s", CIDRKey, path)
-		return ip.IP6Net{}
+		return ip.IP6Net{IP: (*ip.IP6)(big.NewInt(0)), PrefixLen: 0}
 	} else if len(prevCIDRs) > 1 {
 		log.Errorf("error reading subnet: more than 1 entry found for key: %s in file %s: ", CIDRKey, path)
-		return ip.IP6Net{}
+		return ip.IP6Net{IP: (*ip.IP6)(big.NewInt(0)), PrefixLen: 0}
 	} else {
 		return prevCIDRs[0]
 	}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This PR fixes an issue with IPv6 in case of missing configuration the empty network was wrongly initialized to 0 with an error when the bigInt comparison was used. #1968

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
