### PR TITLE
Try several times to contact kube-api before failing

### DIFF
--- a/pkg/backend/vxlan/vxlan_windows.go
+++ b/pkg/backend/vxlan/vxlan_windows.go
@@ -151,7 +151,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGroup,
 		interfaceName: be.extIface.Iface.Name,
 	}
 
-	dev, err := newVXLANDevice(&devAttrs)
+	dev, err := newVXLANDevice(ctx, &devAttrs)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create VXLAN network: %w", err)
 	}
@@ -191,7 +191,7 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGroup,
 	}
 
 	// Before contacting the lease server (e.g. kube-api), we verify that the physical interface is ready
-	err = checkHostNetworkReady(hcnNetwork)
+	err = checkHostNetworkReady(ctx, hcnNetwork)
 	if err != nil {
 		return nil, fmt.Errorf("interface bound to %s took too long to get ready. Please check your network host configuration", hcnNetwork.Name)
 	}


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
When the code tries to get a lease, it contacts kube-api. If dor some reason, the connectivity failed, flanneld will error out and the registration of the network will fail. This PR makes it try several times before really failing so that we can be more resilient.

This PR also replaces some wait.Poll() calls. That one is deprecated

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Retry contacting kube-api when acquiring a lease if it fails
```
