### PR TITLE
Updated Flannel chart with Netpol containter and removed clustercidr

### DIFF
--- a/Documentation/integrations.md
+++ b/Documentation/integrations.md
@@ -4,10 +4,10 @@ This document tracks projects that integrate with flannel. [Join the community](
 
 ## Projects
 
-[Kubernetes](https://kubernetes.io/docs/admin/networking/#flannel): Container orchestration platform with options for [flannel as an overlay](https://kubernetes.io/docs/admin/networking/#flannel).
+[kube-network-policies](https://github.com/kubernetes-sigs/kube-network-policies): Network policies controller that can be deployed alongside Flannel.
 
 [Canal](https://projectcalico.docs.tigera.io/getting-started/kubernetes/flannel/flannel): Kubernetes CNI plugin that uses Calico for network policies and intra-node communications and Flannel for inter-node communications.
 
 [K3s](https://k3s.io/): Kubernetes distribution with flannel embedded as CNI.
 
-[RKE2](https://docs.rke2.io/): Kubernetes distribution packed with Canal as default CNI.
+[RKE2](https://docs.rke2.io/): Kubernetes distribution packed with Canal as default CNI and can be configured with Flannel with support for windows.

--- a/Documentation/kustomization/kube-flannel/kube-flannel.yml
+++ b/Documentation/kustomization/kube-flannel/kube-flannel.yml
@@ -31,13 +31,6 @@ rules:
   - nodes/status
   verbs:
   - patch
-- apiGroups:
-  - "networking.k8s.io"
-  resources:
-  - clustercidrs
-  verbs:
-  - list
-  - watch
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -90,6 +83,7 @@ data:
   net-conf.json: |
     {
       "Network": "10.244.0.0/16",
+      "EnableNFTables": false,
       "Backend": {
         "Type": "vxlan"
       }

--- a/Documentation/netpol.md
+++ b/Documentation/netpol.md
@@ -1,0 +1,11 @@
+# Network policy controller
+
+From v0.25.5 it is possible to deploy Flannel with https://github.com/kubernetes-sigs/kube-network-policies controller to provide a network policy controller within the Flannel CNI.
+
+When deployed with the Helm chart it is enough to enable the `netpol.enabled` value.
+```bash
+helm install flannel --set netpol.enabled=true --namespace kube-flannel flannel/flannel
+```
+
+Flannel pod should start with an additional container and it is possible to configure Network policies.
+Use the kube-network-poilicies documentation to find additional info.

--- a/chart/kube-flannel/templates/config.yaml
+++ b/chart/kube-flannel/templates/config.yaml
@@ -38,6 +38,9 @@ data:
       "IPv6Network": {{ .Values.podCidrv6 | quote }},
       "EnableIPv6": true,
 {{- end }}
+{{- if .Values.flannel.enableNFTables }}
+      "EnableNFTables": true,
+{{- end }}
       "Backend": {
 {{- if eq .Values.flannel.backend "vxlan" }}
 {{- if .Values.flannel.backendPort }}

--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -91,7 +91,33 @@ spec:
           mountPath: /etc/kube-flannel/
         - name: xtables-lock
           mountPath: /run/xtables.lock
+{{- if .Values.netpol.enabled }}
+      - name: kube-network-policies
+        image: {{ .Values.netpol.image.repository }}:{{ .Values.netpol.image.tag }}
+        command:
+        - "/bin/netpol"
+        {{- range .Values.netpol.args }}
+        - {{ . | quote }}
+        {{- end }}
+        volumeMounts:
+        - name: lib-modules
+          mountPath: /lib/modules
+          readOnly: true
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+          capabilities:
+            add: ["NET_ADMIN"]
+{{- end }}
       volumes:
+{{- if .Values.netpol.enabled }}
+      - name: lib-modules
+        hostPath:
+          path: /lib/modules
+{{- end }}
       - name: run
         hostPath:
           path: /run/flannel

--- a/chart/kube-flannel/templates/rbac.yaml
+++ b/chart/kube-flannel/templates/rbac.yaml
@@ -7,12 +7,8 @@ rules:
   - ""
   resources:
   - pods
-  verbs:
-  - get
-- apiGroups:
-  - ""
-  resources:
   - nodes
+  - namespaces
   verbs:
   - get
   - list
@@ -23,13 +19,23 @@ rules:
   - nodes/status
   verbs:
   - patch
+{{- if .Values.netpol.enabled }}
 - apiGroups:
   - "networking.k8s.io"
   resources:
-  - clustercidrs
+  - networkpolicies
   verbs:
   - list
   - watch
+- apiGroups:
+  - "policy.networking.k8s.io"
+  resources:
+  - adminnetworkpolicies
+  - baselineadminnetworkpolicies
+  verbs:
+  - list
+  - watch
+{{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -17,6 +17,7 @@ flannel:
     repository: docker.io/flannel/flannel-cni-plugin
     tag: v1.5.1-flannel1
   # flannel command arguments
+  enableNFTables: false,
   args:
   - "--ip-masq"
   - "--kube-subnet-mgr"
@@ -58,3 +59,12 @@ flannel:
     operator: Exists
   - effect: NoSchedule
     operator: Exists
+
+netpol:
+  enabled: false
+  args:
+  - "--hostname-override=$(MY_NODE_NAME)"
+  - "--v=2"
+  image:
+    repository: registry.k8s.io/networking/kube-network-policies
+    tag: v0.4.0


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This PR removes the clustercidr reference from the chart and the manifest and adds an initial support for the networkpolicy controller with the deployment of the container alongside the flannel daemonset #2004

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
