### PR TITLE
Update k8s version in e2e tests to v1.29.8

### DIFF
--- a/.github/workflows/e2eTests.yaml
+++ b/.github/workflows/e2eTests.yaml
@@ -6,6 +6,7 @@ jobs:
   e2e-test:
     name: test
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5

--- a/.github/workflows/k3s-e2eTests.yml
+++ b/.github/workflows/k3s-e2eTests.yml
@@ -11,6 +11,7 @@ jobs:
   k3s-e2e-tests:
     name: test
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
       - name: Set up Go 1.x

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ e2e-test: bash_unit dist/flanneld-e2e-$(TAG)-$(ARCH).docker
 	FLANNEL_DOCKER_IMAGE=$(REGISTRY):$(TAG)-$(ARCH) ./bash_unit dist/functional-test.sh
 	FLANNEL_DOCKER_IMAGE=$(REGISTRY):$(TAG)-$(ARCH) ./bash_unit dist/functional-test-k8s.sh
 
-k3s-e2e-test: bash_unit
+k3s-e2e-test: bash_unit dist/flanneld-e2e-$(TAG)-$(ARCH).docker
 	$(MAKE) -C images/iperf3 ARCH=$(ARCH)
 	./bash_unit ./e2e/run-e2e-tests.sh
 

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ endif
 GO_VERSION=1.22
 
 # K8s version used for Makefile helpers
-K8S_VERSION=1.24.6
+K8S_VERSION=1.29.8
 
 GOARM=7
 

--- a/dist/functional-test-k8s.sh
+++ b/dist/functional-test-k8s.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 ARCH="${ARCH:-amd64}"
-ETCD_IMG="${ETCD_IMG:-quay.io/coreos/etcd:v3.5.12}"
+ETCD_IMG="${ETCD_IMG:-quay.io/coreos/etcd:v3.5.15}"
 ETCD_LOCATION="${ETCD_LOCATION:-etcd}"
 FLANNEL_NET="${FLANNEL_NET:-10.10.0.0/16}"
 TAG=`git describe --tags --always`
 FLANNEL_DOCKER_IMAGE="${FLANNEL_DOCKER_IMAGE:-quay.io/coreos/flannel:$TAG}"
-K8S_VERSION="${K8S_VERSION:-1.28.7}"
+K8S_VERSION="${K8S_VERSION:-1.29.8}"
 HYPERKUBE_IMG="docker.io/rancher/hyperkube"
 HYPERKUBE_CMD="${HYPERKUBE_CMD:-" "}"
 HYPERKUBE_APISERVER_CMD="${HYPERKUBE_APISERVER_CMD:-kube-apiserver}"
@@ -74,7 +74,7 @@ EOF
     openssl req -new -key $dir/pki/admin.key -subj "/CN=admin/O=system:masters" -out $dir/pki/admin.csr
     openssl x509 -req -in $dir/pki/admin.csr -CA $dir/pki/ca.crt -CAkey $dir/pki/ca.key -CAcreateserial  -out $dir/pki/admin.crt -days 1000
     
-    docker run -d --net=host -v $dir:/var/lib/kubernetes --name flannel-e2e-k8s-apiserver ${HYPERKUBE_IMG}:v$K8S_VERSION-rancher1-linux-$ARCH \
+    docker run -d --net=host -v $dir:/var/lib/kubernetes --name flannel-e2e-k8s-apiserver ${HYPERKUBE_IMG}:v$K8S_VERSION-rancher1 \
       ${HYPERKUBE_CMD} ${HYPERKUBE_APISERVER_CMD} --etcd-servers=$etcd_endpt --bind-address=$docker_ip \
       --client-ca-file=/var/lib/kubernetes/pki/ca.crt \
       --enable-admission-plugins=NodeRestriction,ServiceAccount \
@@ -258,5 +258,5 @@ test_manifest() {
 
     docker exec -i flannel-e2e-k8s-apiserver cat /var/lib/kubernetes/admin.kubeconfig > $dir/admin.kubeconfig
     # This just tests that the API server accepts the manifest, not that it actually acts on it correctly.
-    assert "cat ../Documentation/kube-flannel.yml |  docker run -v $dir:/var/lib/kubernetes -i --rm --net=host ${HYPERKUBE_IMG}:v$K8S_VERSION-rancher1-linux-$ARCH ${HYPERKUBE_CMD} kubectl --kubeconfig=/var/lib/kubernetes/admin.kubeconfig create -f -"
+    assert "cat ../Documentation/kube-flannel.yml |  docker run -v $dir:/var/lib/kubernetes -i --rm --net=host ${HYPERKUBE_IMG}:v$K8S_VERSION-rancher1 ${HYPERKUBE_CMD} kubectl --kubeconfig=/var/lib/kubernetes/admin.kubeconfig create -f -"
 }

--- a/e2e/Dockerfile
+++ b/e2e/Dockerfile
@@ -3,8 +3,8 @@
 ARG SLES="registry.suse.com/suse/sle15:15.4"
 FROM ${SLES} AS k3s
 ARG ARCH
-ARG K3S_VERSION="v1.28.7+k3s1"
-ARG CNI_VERSION="v1.1.1" 
+ARG K3S_VERSION="v1.29.8+k3s1"
+ARG CNI_VERSION="v1.5.1" 
 RUN set -x \
  && zypper -n in \
     ca-certificates \

--- a/e2e/download-kubectl.sh
+++ b/e2e/download-kubectl.sh
@@ -6,6 +6,6 @@ source $(dirname $0)/version.sh
 
 RELEASE="$(curl -sSL https://dl.k8s.io/release/stable.txt)"
 pushd /usr/local/bin
-sudo curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/${ARCH:-amd64}/kubectl
+sudo curl -L --remote-name-all https://dl.k8s.io/release/${RELEASE}/bin/linux/${ARCH:-amd64}/kubectl
 sudo chmod +x kubectl
 popd


### PR DESCRIPTION
## Description
Update the version of k8s that we use for the end to end tests.

also change the download url for `kubectl` as the old one does not have the most recent versions

and add 90m timeouts to test workflows so that we don't consume the CI budget for no reason when there is an issue
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
