### PR TITLE
check that the lease includes an IP address of the requested family before configuring the flannel interface

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -42,9 +42,9 @@ jobs:
           ARCH=amd64 TAG=${{ github.sha }} make image
 
       - name: Run Trivy vulnerability scanner in tarball mode
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@0.28.0
         with:
-          input: /github/workspace/dist/flanneld-${{ github.sha }}-amd64.docker
+          input: ./dist/flanneld-${{ github.sha }}-amd64.docker
           severity: 'CRITICAL,HIGH'
           format: 'sarif'
           output: 'trivy-results.sarif'

--- a/pkg/backend/vxlan/vxlan.go
+++ b/pkg/backend/vxlan/vxlan.go
@@ -220,11 +220,17 @@ func (be *VXLANBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGroup,
 	// This IP is just used as a source address for host to workload traffic (so
 	// the return path for the traffic has an address on the flannel network to use as the destination)
 	if config.EnableIPv4 {
+		if lease.Subnet.Empty() {
+			return nil, fmt.Errorf("failed to configure interface %s: IPv4 is enabled but the lease has no IPv4", dev.link.Attrs().Name)
+		}
 		if err := dev.Configure(ip.IP4Net{IP: lease.Subnet.IP, PrefixLen: 32}, config.Network); err != nil {
 			return nil, fmt.Errorf("failed to configure interface %s: %w", dev.link.Attrs().Name, err)
 		}
 	}
 	if config.EnableIPv6 {
+		if lease.IPv6Subnet.Empty() {
+			return nil, fmt.Errorf("failed to configure interface %s: IPv6 is enabled but the lease has no IPv6", v6Dev.link.Attrs().Name)
+		}
 		if err := v6Dev.ConfigureIPv6(ip.IP6Net{IP: lease.IPv6Subnet.IP, PrefixLen: 128}, config.IPv6Network); err != nil {
 			return nil, fmt.Errorf("failed to configure interface %s: %w", v6Dev.link.Attrs().Name, err)
 		}

--- a/pkg/backend/wireguard/wireguard.go
+++ b/pkg/backend/wireguard/wireguard.go
@@ -171,6 +171,10 @@ func (be *WireguardBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGr
 	}
 
 	if config.EnableIPv4 {
+		if lease.Subnet.Empty() {
+			return nil, fmt.Errorf("failed to configure wg interface: IPv4 is enabled but the lease has no IPv4")
+		}
+
 		err = dev.Configure(lease.Subnet.IP, config.Network)
 		if err != nil {
 			return nil, err
@@ -178,6 +182,10 @@ func (be *WireguardBackend) RegisterNetwork(ctx context.Context, wg *sync.WaitGr
 	}
 
 	if config.EnableIPv6 {
+		if lease.IPv6Subnet.Empty() {
+			return nil, fmt.Errorf("failed to configure wg interface: IPv6 is enabled but the lease has no IPv6")
+		}
+
 		if cfg.Mode == Separate {
 			err = v6Dev.ConfigureV6(lease.IPv6Subnet.IP, config.IPv6Network)
 		} else {


### PR DESCRIPTION
If we try for example to use IPv6 without having configured an IPv6 ClusterCIDR, flannel can crash.

This PR makes sure flannel stops at startup with a more explicit error message.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
