### PR TITLE
Added checks for br_netfilter module

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ curl -O -L https://github.com/containernetworking/plugins/releases/download/v1.5
 tar -C /opt/cni/bin -xzf cni-plugins-linux-$ARCH-v1.5.1.tgz
 ```
 
+Flannel requires the br_netfilter module to start and from version 1.30 kubeadm doesn't check if the module is installed and Flannel will not rightly start in case the module is missing.
+
 ## Getting started on Docker
 
 flannel is also widely used outside of kubernetes. When deployed outside of kubernetes, etcd is always used as the datastore. For more details integrating flannel with Docker see [Running](Documentation/running.md)

--- a/main.go
+++ b/main.go
@@ -261,6 +261,20 @@ func main() {
 		os.Exit(1)
 	}
 
+	// From Kubernetes 1.30 kubeadm doesn't check if the br_netfilter module is loaded and in case it's missing Flannel wrongly starts
+	if config.EnableIPv4 {
+		if _, err = os.Stat("/proc/sys/net/bridge/bridge-nf-call-iptables"); os.IsNotExist(err) {
+			log.Error("Failed to check br_netfilter: ", err)
+			os.Exit(1)
+		}
+	}
+	if config.EnableIPv6 {
+		if _, err = os.Stat("/proc/sys/net/bridge/bridge-nf-call-ip6tables"); os.IsNotExist(err) {
+			log.Error("Failed to check br_netfilter: ", err)
+			os.Exit(1)
+		}
+	}
+
 	// Work out which interface to use
 	var extIface *backend.ExternalInterface
 


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This PR adds a check to verify if the file bridge-nf-call-iptables is present to check if the br_netfilter module is loaded.
The check was done by kubeadm before but was removed from 1.30 #2068

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
