### PR TITLE
fix: add missing MY_NODE_NAME environment variable in chart

### DIFF
--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -99,6 +99,11 @@ spec:
         {{- range .Values.netpol.args }}
         - {{ . | quote }}
         {{- end }}
+        env:
+        - name: MY_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         volumeMounts:
         - name: lib-modules
           mountPath: /lib/modules


### PR DESCRIPTION
## Description

Fix: Add missing MY_NODE_NAME environment variable in chart.

"NodeName" is now set to "$(my_node_name)".

```bash
# kubectl -n kube-flannel logs -f kube-flannel-ds-fqmw5 -c kube-network-policies
I0101 11:55:44.275697       1 main.go:59] flags: []
I0101 11:55:44.301143       1 controller.go:83] Creating event broadcaster
I0101 11:55:44.301355       1 controller.go:89] Creating controller: networkpolicy.Config{FailOpen:false, AdminNetworkPolicy:false, BaselineAdminNetworkPolicy:false, QueueID:100, NodeName:"$(my_node_name)"}
```

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
None required
```
