### PR TITLE
feat: add bool to control CNI config installation using Helm

### DIFF
--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -44,6 +44,7 @@ spec:
         volumeMounts:
         - name: cni-plugin
           mountPath: /opt/cni/bin
+      {{- if not .Values.flannel.skipCNIConfigInstallation }}
       - name: install-cni
         image: {{ .Values.flannel.image.repository }}:{{ .Values.flannel.image.tag }}
         command:
@@ -57,6 +58,7 @@ spec:
           mountPath: /etc/cni/net.d
         - name: flannel-cfg
           mountPath: /etc/kube-flannel/
+      {{- end }}
       containers:
       - name: kube-flannel
         image: {{ .Values.flannel.image.repository }}:{{ .Values.flannel.image.tag }}

--- a/chart/kube-flannel/tests/daemonset_test.yaml
+++ b/chart/kube-flannel/tests/daemonset_test.yaml
@@ -55,3 +55,21 @@ tests:
           path: spec.template.spec.imagePullSecrets
           value:
             - name: "a-test-secret"
+
+  - it: should add the install-cni init container when default values are used
+    asserts:
+      - contains:
+          path: spec.template.spec.initContainers
+          content:
+            name: install-cni
+          any: true
+
+  - it: should not add the install-cni init container when skipCNIConfigInstallation is set
+    set:
+      flannel.skipCNIConfigInstallation: true
+    asserts:
+      - notContains:
+          path: spec.template.spec.initContainers
+          content:
+            name: install-cni
+          any: true

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -16,6 +16,9 @@ flannel:
   image_cni:
     repository: docker.io/flannel/flannel-cni-plugin
     tag: v1.6.0-flannel1
+  # skipCNIConfigInstallation skips the installation of the flannel CNI config. This is useful when the CNI config is
+  # provided externally.
+  skipCNIConfigInstallation: false
   # flannel command arguments
   enableNFTables: false
   args:


### PR DESCRIPTION


## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

This feature enables more controlled installation of CNI configs in setups where more than one CNI is used. It helps prevent race conditions during initial node bootstrapping.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Add bool to control CNI config installation using Helm
```
