### PR TITLE
Prepare for flannel release v0.26.3

### DIFF
--- a/Documentation/kube-flannel-psp.yml
+++ b/Documentation/kube-flannel-psp.yml
@@ -177,7 +177,7 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-        image: docker.io/flannel/flannel:v0.26.2
+        image: docker.io/flannel/flannel:v0.26.3
         command:
         - cp
         args:
@@ -191,7 +191,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: docker.io/flannel/flannel:v0.26.2
+        image: docker.io/flannel/flannel:v0.26.3
         command:
         - /opt/bin/flanneld
         args:

--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -144,7 +144,7 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-        image: docker.io/flannel/flannel:v0.26.2
+        image: docker.io/flannel/flannel:v0.26.3
         command:
         - cp
         args:
@@ -158,7 +158,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: docker.io/flannel/flannel:v0.26.2
+        image: docker.io/flannel/flannel:v0.26.3
         command:
         - /opt/bin/flanneld
         args:

--- a/Documentation/kustomization/kube-flannel-psp/kube-flannel-psp.yml
+++ b/Documentation/kustomization/kube-flannel-psp/kube-flannel-psp.yml
@@ -177,7 +177,7 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-        image: docker.io/flannel/flannel:v0.26.2
+        image: docker.io/flannel/flannel:v0.26.3
         command:
         - cp
         args:
@@ -191,7 +191,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: docker.io/flannel/flannel:v0.26.2
+        image: docker.io/flannel/flannel:v0.26.3
         command:
         - /opt/bin/flanneld
         args:

--- a/Documentation/kustomization/kube-flannel/kube-flannel.yml
+++ b/Documentation/kustomization/kube-flannel/kube-flannel.yml
@@ -135,7 +135,7 @@ spec:
         - name: cni-plugin
           mountPath: /opt/cni/bin
       - name: install-cni
-        image: docker.io/flannel/flannel:v0.26.2
+        image: docker.io/flannel/flannel:v0.26.3
         command:
         - cp
         args:
@@ -149,7 +149,7 @@ spec:
           mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
-        image: docker.io/flannel/flannel:v0.26.2
+        image: docker.io/flannel/flannel:v0.26.3
         command:
         - /opt/bin/flanneld
         args:

--- a/Documentation/kustomization/kube-flannel/kustomization.yaml
+++ b/Documentation/kustomization/kube-flannel/kustomization.yaml
@@ -6,4 +6,4 @@ resources:
 - kube-flannel.yml
 images:
 - name: docker.io/flannel/flannel
-  newTag: v0.26.2
+  newTag: v0.26.3

--- a/chart/kube-flannel/Chart.yaml
+++ b/chart/kube-flannel/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: v0.26.2
+appVersion: v0.26.3
 description: Install Flannel Network Plugin.
 keywords:
 - Flannel
 name: flannel
 sources:
 - https://github.com/flannel-io/flannel
-version: v0.26.2
+version: v0.26.3

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -12,7 +12,7 @@ flannel:
   # kube-flannel image
   image:
     repository: docker.io/flannel/flannel
-    tag: v0.26.2
+    tag: v0.26.3
   image_cni:
     repository: docker.io/flannel/flannel-cni-plugin
     tag: v1.6.0-flannel1


### PR DESCRIPTION
Fixes #2158

## Description
Prepare for flannel release v0.26.3.
This step seems to have been missed when cutting the v0.26.3 branch.

## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note
```release-note
Prepare for flannel release v0.26.3.
```
