### PR TITLE
Refactor: Rename SetUpNetlinkTest to TestSetUpNetlink for consistency

### DIFF
--- a/pkg/backend/route_network_test.go
+++ b/pkg/backend/route_network_test.go
@@ -22,13 +22,10 @@ import (
 
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/pkg/lease"
-	"github.com/flannel-io/flannel/pkg/ns"
 	"github.com/vishvananda/netlink"
 )
 
 func TestRouteCache(t *testing.T) {
-	teardown := ns.SetUpNetlinkTest(t)
-	defer teardown()
 
 	lo, err := netlink.LinkByName("lo")
 	if err != nil {
@@ -79,8 +76,6 @@ func TestRouteCache(t *testing.T) {
 }
 
 func TestV6RouteCache(t *testing.T) {
-	teardown := ns.SetUpNetlinkTest(t)
-	defer teardown()
 
 	la := netlink.NewLinkAttrs()
 	la.Name = "br"

--- a/pkg/ip/iface_test.go
+++ b/pkg/ip/iface_test.go
@@ -21,13 +21,10 @@ import (
 	"net"
 	"testing"
 
-	"github.com/flannel-io/flannel/pkg/ns"
 	"github.com/vishvananda/netlink"
 )
 
 func TestEnsureV4AddressOnLink(t *testing.T) {
-	teardown := ns.SetUpNetlinkTest(t)
-	defer teardown()
 	lo, err := netlink.LinkByName("lo")
 	if err != nil {
 		t.Fatal(err)
@@ -65,8 +62,6 @@ func TestEnsureV4AddressOnLink(t *testing.T) {
 }
 
 func TestEnsureV6AddressOnLink(t *testing.T) {
-	teardown := ns.SetUpNetlinkTest(t)
-	defer teardown()
 	lo, err := netlink.LinkByName("lo")
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/ns/ns_test.go
+++ b/pkg/ns/ns_test.go
@@ -16,3 +16,25 @@
 // limitations under the License.
 
 package ns
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/vishvananda/netns"
+)
+
+func TestSetUpNetlink(t *testing.T) {
+	// new temporary namespace so we don't pollute the host
+	// lock thread since the namespace is thread local
+	runtime.LockOSThread()
+	var err error
+	ns, err := netns.New()
+	if err != nil {
+		t.Fatalf("Failed to create newns: %v", err)
+	}
+
+	defer ns.Close()
+	defer runtime.UnlockOSThread()
+
+}


### PR DESCRIPTION
In pkg/ns/ns.go, which is a test file, the function SetUpNetlinkTest is actually a test case. To adhere to Go's testing framework conventions and improve code readability, we rename it to TestSetUpNetlink.

The previous name did not follow the standard naming convention for test functions, which should start with 'Test' to be recognized by the testing framework.

Changes:
- Renamed SetUpNetlinkTest to TestSetUpNetlink.
- Updated the function signature to match Go's testing framework requirements (no return value).

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
