### PR TITLE
enable setting CNI directory paths in helm chart

### DIFF
--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -130,10 +130,10 @@ spec:
           path: /run/flannel
       - name: cni-plugin
         hostPath:
-          path: /opt/cni/bin
+          path: {{ .Values.flannel.cniBinDir }}
       - name: cni
         hostPath:
-          path: /etc/cni/net.d
+          path: {{ .Values.flannel.cniConfDir }}
       - name: flannel-cfg
         configMap:
           name: kube-flannel-cfg

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -16,6 +16,10 @@ flannel:
   image_cni:
     repository: ghcr.io/flannel-io/flannel-cni-plugin
     tag: v1.6.2-flannel1
+  # cniBinDir is the directory to which the flannel CNI binary is installed.
+  cniBinDir: "/opt/cni/bin"
+  # cniConfDir is the directory where the CNI configuration is located.
+  cniConfDir: "/etc/cni/net.d"
   # skipCNIConfigInstallation skips the installation of the flannel CNI config. This is useful when the CNI config is
   # provided externally.
   skipCNIConfigInstallation: false


### PR DESCRIPTION
enable setting the location of the CNI directories in the helm chart.


```release-note
None required
```
