### PR TITLE
refactor release.yaml to reduce use of potentially vulnerable GH Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,10 +128,6 @@ jobs:
           push-to-registry: true
 
   build-and-push-artifacts:
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -158,17 +154,25 @@ jobs:
         run: make release
 
       - name: Upload release files
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            dist/flannel*
-            dist/kube-flannel.yml
-            dist/kube-flannel-psp.yml
+        run: gh release upload ${{ env.GIT_TAG }} dist/flannel* dist/kube-flannel.yml dist/kube-flannel-psp.yml
 
-      - name: Wait for previous job
-        uses: yogeshlonkar/wait-for-jobs@v0.2.1
-        with:
-          jobs: build-and-push-images
+  publish-chart:
+    permissions:
+      pages: write      # to deploy to Pages
+      id-token: write   # to verify the deployment originates from an appropriate source
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    needs: build-and-push-images
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Package chart
+        run: make release-chart release-helm
 
       - name: Setup Pages
         uses: actions/configure-pages@v4

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test unit-test e2e-test deps cover gofmt gofmt-fix license-check clean tar.gz release buildx-create-builder build-multi-arch
+.PHONY: test unit-test e2e-test deps cover gofmt gofmt-fix license-check clean tar.gz release buildx-create-builder build-multi-arch release-chart release-helm
 
 # Registry used for publishing images
 REGISTRY?=quay.io/coreos/flannel
@@ -153,7 +153,7 @@ endif
 
 # Make a release after creating a tag
 # To build cross platform Docker images, the qemu-static binaries are needed. On ubuntu "apt-get install  qemu-user-static"
-release: tar.gz dist/qemu-s390x-static dist/qemu-ppc64le-static dist/qemu-arm64-static dist/qemu-arm-static dist/qemu-riscv64-static release-chart release-helm
+release: tar.gz dist/qemu-s390x-static dist/qemu-ppc64le-static dist/qemu-arm64-static dist/qemu-arm-static dist/qemu-riscv64-static
 	ARCH=amd64 make dist/flanneld-$(TAG)-amd64.docker
 	ARCH=arm make dist/flanneld-$(TAG)-arm.docker
 	ARCH=arm64 make dist/flanneld-$(TAG)-arm64.docker


### PR DESCRIPTION
## Description
As we've seen with `tj-actions/changed-files`, GHA can be compromised so we can enhance the repo's security by reducing our use of unnecessary third-party actions.

This PR removes the two third-party action that we used in our release workflow:
- softprops/action-gh-release
- yogeshlonkar/wait-for-jobs

Ref: https://www.stepsecurity.io/blog/harden-runner-detection-tj-actions-changed-files-action-is-compromised

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
