### PR TITLE
enable setting resources in helm chart

### DIFF
--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -67,10 +67,10 @@ spec:
         {{- range .Values.flannel.args }}
         - {{ . | quote }}
         {{- end }}
+        {{- with .Values.flannel.resources }}
         resources:
-          requests:
-            cpu: "100m"
-            memory: "50Mi"
+          {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
         securityContext:
           privileged: false
           capabilities:

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -82,6 +82,10 @@ flannel:
   #
   # General daemonset configs
   #
+  resources:
+    requests:
+      cpu: 100m
+      memory: 50Mi
   tolerations:
   - effect: NoExecute
     operator: Exists


### PR DESCRIPTION
## Description
- Add resources for the `kube-flannel` container to the helm chart
- Tested with helm v3.18.1 and kubernetes v1.32.5

## Release Note
```release-note
None required
```
