### PR TITLE
Fix deadlock in startup for large clusters

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -99,6 +99,8 @@ Any command line option can be turned into an environment variable by prefixing 
 
 `EVENT_QUEUE_DEPTH` is another environment variable to indicate the kubernetes scale. Set `EVENT_QUEUE_DEPTH` to adapter your cluster node numbers. If not set, default value is 5000. 
 
+`CONT_WHEN_CACHE_NOT_READY` is environment variable to indicate if flanneld should continue even when the node informer cache is not fully sync'd yet. This can happen for large clusters (clusters with node capacity higher than `EVENT_QUEUE_DEPTH`). Set `CONT_WHEN_CACHE_NOT_READY` to "true" to let flanneld not fail startup for such large capacity clusters.
+
 ## Health Check
 
 Flannel provides a health check http endpoint `healthz`. Currently this endpoint will blindly

--- a/Documentation/kube-flannel-psp.yml
+++ b/Documentation/kube-flannel-psp.yml
@@ -216,6 +216,8 @@ spec:
               fieldPath: metadata.namespace
         - name: EVENT_QUEUE_DEPTH
           value: "5000"
+        - name: CONT_WHEN_CACHE_NOT_READY
+          value: "false"
         volumeMounts:
         - name: run
           mountPath: /run/flannel

--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -183,6 +183,8 @@ spec:
               fieldPath: metadata.namespace
         - name: EVENT_QUEUE_DEPTH
           value: "5000"
+        - name: CONT_WHEN_CACHE_NOT_READY
+          value: "false"
         volumeMounts:
         - name: run
           mountPath: /run/flannel

--- a/Documentation/kustomization/kube-flannel-psp/kube-flannel-psp.yml
+++ b/Documentation/kustomization/kube-flannel-psp/kube-flannel-psp.yml
@@ -216,6 +216,8 @@ spec:
               fieldPath: metadata.namespace
         - name: EVENT_QUEUE_DEPTH
           value: "5000"
+        - name: CONT_WHEN_CACHE_NOT_READY
+          value: "false"
         volumeMounts:
         - name: run
           mountPath: /run/flannel

--- a/Documentation/kustomization/kube-flannel/kube-flannel.yml
+++ b/Documentation/kustomization/kube-flannel/kube-flannel.yml
@@ -174,6 +174,8 @@ spec:
               fieldPath: metadata.namespace
         - name: EVENT_QUEUE_DEPTH
           value: "5000"
+        - name: CONT_WHEN_CACHE_NOT_READY
+          value: "false"
         volumeMounts:
         - name: run
           mountPath: /run/flannel

--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -86,6 +86,8 @@ spec:
               fieldPath: metadata.namespace
         - name: EVENT_QUEUE_DEPTH
           value: "5000"
+        - name: CONT_WHEN_CACHE_NOT_READY
+          value: "false"
         volumeMounts:
         - name: run
           mountPath: /run/flannel

--- a/go.mod
+++ b/go.mod
@@ -34,6 +34,7 @@ require (
 	github.com/avast/retry-go/v4 v4.6.1
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.1192
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/vpc v1.0.1186
+	golang.org/x/sync v0.13.0
 	sigs.k8s.io/knftables v0.0.18
 )
 
@@ -84,7 +85,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.31.0 // indirect
 	go.opentelemetry.io/otel/trace v1.31.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.0.0 // indirect
-	golang.org/x/sync v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20241015192408-796eee8c2d53 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20241015192408-796eee8c2d53 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect

--- a/main.go
+++ b/main.go
@@ -225,7 +225,8 @@ func main() {
 
 	sm, err := newSubnetManager(ctx)
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) {
+		contCacheNotReady := os.Getenv("CONT_WHEN_CACHE_NOT_READY")
+		if contCacheNotReady == "true" && errors.Is(err, context.DeadlineExceeded) {
 			log.Error("Timed out waiting for node controller sync. Continuing anyway.")
 			// Don't exit — continue with startup
 		} else {

--- a/main.go
+++ b/main.go
@@ -225,8 +225,13 @@ func main() {
 
 	sm, err := newSubnetManager(ctx)
 	if err != nil {
-		log.Error("Failed to create SubnetManager: ", err)
-		os.Exit(1)
+		if errors.Is(err, context.DeadlineExceeded) {
+			log.Error("Timed out waiting for node controller sync. Continuing anyway.")
+			// Don't exit — continue with startup
+		} else {
+			log.Error("Failed to create SubnetManager: ", err)
+			os.Exit(1)
+		}
 	}
 	log.Infof("Created subnet manager: %s", sm.Name())
 

--- a/pkg/subnet/kube/kube.go
+++ b/pkg/subnet/kube/kube.go
@@ -154,7 +154,7 @@ func NewSubnetManager(ctx context.Context, apiUrl, kubeconfig, prefix, netConfPa
 		})
 
 		if err != nil {
-			log.Error("Node controller sync not completed yet ", err)
+			log.Errorf("Node controller sync not completed within 1s: %v", err)
 			return sm, fmt.Errorf("error waiting for nodeController to sync state: %w", err)
 		}
 		log.Infof("Node controller sync successful")


### PR DESCRIPTION
## Description

Issue: #2252 

Channel event queue is a sized buffer (default=5000) and ends up blocking if there are events that are higher than the buffer size. This can happen on a large cluster with 5K nodes. Flannel sets up the informers during startup and while the informer callbacks occur asynchronously, NewSubnetManager uses a wait.PollUntilContextTimeout() to check for informer sync completion (with a timeout of 10 min). The problem is AddEvent blocks when the channel buffer is full holding the DeltaFIFO lock that is also needed by cache controller's HasSynced() which is checked in the callback for wait.PollUntilContextTimeout(). This results in a deadlock where the main thread is indefinitely blocked.

Below is the summary from stacktrace on a stuck flanneld due to this issue.

| Goroutine | Waiting On                                          | Why                                 |
| --------: | --------------------------------------------------- | ----------------------------------- |
|    **81** | Sending to a **channel** in `handleAddLeaseEvent()` | Channel is full or receiver is gone |
|         1 | `.HasSynced()` → needs lock                         | Main goroutine, can't proceed       |
|        88 | `.Resync()` → needs lock                            | Reflector, also blocked             |
|       116 | `.Update()` → needs lock                            | Reflector, blocked too              |

This PR makes the AddLeaseEvent and UpdateLeaseEvent non-blocking with async adds with a fixed concurrency using goroutines when exceeding the buffer size. Any events that can not fit into the channel buffer are queued for subsequent processing.

Additionally, when this happens, since wait.PollUntilContextTimeout() results in a timeout, relaxes the fatal condition on main for timeout by ignoring a timeout error to allow for the backend consumer to be setup which results in draining the channel event queue and thus frees up space to process the queued events

Other reference PRs:
https://github.com/flannel-io/flannel/issues/719
https://github.com/flannel-io/flannel/pull/729
https://github.com/flannel-io/flannel/pull/2248

Note that the mechanism implemented in the PR to back off and retry excess events is applicable even outside of the startup to handle back pressure from the backends and filling up of the channel event buffer during runtime.

## Todos
- [x] Tests

Deadlock logs:
------------
```
queue size : 50
cluster size: 196

I0618 21:13:39.194940       1 kube.go:511] Creating the node lease for IPv4. This is the n.Spec.PodCIDRs: [100.96.97.128/25]
I0618 21:13:39.194947       1 kube.go:511] Creating the node lease for IPv4. This is the n.Spec.PodCIDRs: [100.96.127.0/25]
I0618 21:13:39.194954       1 kube.go:511] Creating the node lease for IPv4. This is the n.Spec.PodCIDRs: [100.96.105.128/25]
I0618 21:13:39.194963       1 kube.go:511] Creating the node lease for IPv4. This is the n.Spec.PodCIDRs: [100.96.130.128/25]
I0618 21:13:39.194969       1 kube.go:511] Creating the node lease for IPv4. This is the n.Spec.PodCIDRs: [100.96.124.128/25]
I0618 21:13:39.194977       1 kube.go:511] Creating the node lease for IPv4. This is the n.Spec.PodCIDRs: [100.96.126.128/25]
I0618 21:13:39.194985       1 kube.go:511] Creating the node lease for IPv4. This is the n.Spec.PodCIDRs: [100.96.15.0/25]
I0618 21:13:39.194992       1 kube.go:511] Creating the node lease for IPv4. This is the n.Spec.PodCIDRs: [100.96.125.0/25]
I0618 21:13:39.194998       1 kube.go:511] Creating the node lease for IPv4. This is the n.Spec.PodCIDRs: [100.96.125.128/25]
I0618 21:18:39.195302       1 reflector.go:281] github.com/flannel-io/flannel/pkg/subnet/kube/kube.go:491: forcing resync
```

Logs with Fix:
```
queue size : 50
cluster size: 196
E0619 00:39:09.459563       1 kube.go:157] Node controller sync not completed yet context deadline exceeded
E0619 00:39:09.459617       1 main.go:229] Timed out waiting for node controller sync. Continuing anyway.
I0619 00:39:09.459623       1 main.go:236] Created subnet manager: Kubernetes Subnet Manager - ......
I0619 00:39:09.459627       1 main.go:239] Installing signal handlers
I0619 00:39:09.459689       1 main.go:484] Found network config - Backend type: vxlan
I0619 00:39:09.462607       1 kube.go:714] List of node annotations: .....
I0619 00:39:09.462642       1 match.go:211] Determining IP address of default interface
I0619 00:39:09.463503       1 match.go:264] Using interface with name bond0 and address 10.116.9.204
I0619 00:39:09.463518       1 match.go:286] Defaulting external address to interface address (10.116.9.204)
I0619 00:39:09.463555       1 vxlan.go:141] VXLAN config: VNI=1 Port=0 GBP=false Learning=false DirectRouting=false
I0619 00:39:09.465517       1 kube.go:681] List of node annotations: ....
I0619 00:39:09.465546       1 vxlan.go:155] Interface flannel.1 mac address set to: 8e:51:89:39:41:0d

I0619 00:37:48.697825       1 kube.go:250] Channel buffer full, add event asynchronously
E0619 00:39:48.602228       1 kube.go:157] Node controller sync not completed yet context deadline exceeded
E0619 00:39:48.602274       1 main.go:229] Timed out waiting for node controller sync. Continuing anyway.
I0619 00:39:48.602281       1 main.go:236] Created subnet manager: Kubernetes Subnet Manager - lor1-0005164.int.linkedin.com
I0619 00:39:48.602284       1 main.go:239] Installing signal handlers
I0619 00:39:48.602357       1 main.go:484] Found network config - Backend type: vxlan
I0619 00:39:48.605857       1 kube.go:714] List of node annotations: ..........
I0619 00:39:48.605909       1 match.go:211] Determining IP address of default interface
I0619 00:39:48.606908       1 match.go:264] Using interface with name bond0 and address 10.190.231.115
I0619 00:39:48.606924       1 match.go:286] Defaulting external address to interface address (10.190.231.115)


```
