### PR TITLE
Added flag to enable blackhole route locally for Canal

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -119,7 +119,7 @@ require (
 	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/sys v0.32.0
 	golang.org/x/term v0.30.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/grpc v1.69.0 // indirect

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -25,7 +25,7 @@ RUN export GOOS=$(xx-info os) &&\
     export ARCH=$(xx-info arch) &&\
     make build
 
-FROM alpine:20250108
+FROM alpine:3.22.0
 RUN apk update && apk upgrade
 RUN apk add --no-cache iproute2 ca-certificates nftables iptables strongswan iptables-legacy && update-ca-certificates
 RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community

--- a/pkg/ip/iface.go
+++ b/pkg/ip/iface.go
@@ -24,6 +24,7 @@ import (
 	"syscall"
 
 	"github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 	log "k8s.io/klog/v2"
 )
 
@@ -328,4 +329,22 @@ func EnsureV6AddressOnLink(ipa IP6Net, ipn IP6Net, link netlink.Link) error {
 	}
 
 	return nil
+}
+
+func AddBlackholeV4Route(ipV4Dest *net.IPNet) error {
+	route := netlink.Route{Dst: ipV4Dest, Type: unix.RTN_BLACKHOLE, Family: netlink.FAMILY_V4}
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V4, &route, netlink.RT_FILTER_DST|netlink.RT_FILTER_TYPE)
+	if err != nil && len(routes) == 0 {
+		err = netlink.RouteAdd(&route)
+	}
+	return err
+}
+
+func AddBlackholeV6Route(ipV6Dest *net.IPNet) error {
+	route := netlink.Route{Dst: ipV6Dest, Type: unix.RTN_BLACKHOLE, Family: netlink.FAMILY_V6}
+	routes, err := netlink.RouteListFiltered(netlink.FAMILY_V6, &route, netlink.RT_FILTER_DST|netlink.RT_FILTER_TYPE)
+	if err != nil && len(routes) == 0 {
+		err = netlink.RouteAdd(&route)
+	}
+	return err
 }

--- a/pkg/ip/iface_windows.go
+++ b/pkg/ip/iface_windows.go
@@ -156,3 +156,5 @@ func GetInterfaceByIP6(ip net.IP) (*net.Interface, error)                       
 func GetInterfaceIP6Addrs(iface *net.Interface) ([]net.IP, error)               { return nil, nil }
 func GetInterfaceBySpecificIPRouting(ip net.IP) (*net.Interface, net.IP, error) { return nil, nil, nil }
 func GetDefaultV6GatewayInterface() (*net.Interface, error)                     { return nil, nil }
+func AddBlackholeV4Route(ipV4Dest *net.IPNet) error                             { return nil }
+func AddBlackholeV6Route(ipV6Dest *net.IPNet) error                             { return nil }


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->
This PR adds a flag `--ip-blackhole-route` to enable a blackhole route for the local CIDR in case the bridge CNI plugin is not enabled like in Canal
This should fixes #2245
## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
