### PR TITLE
Allow me to designate a nodeSelector in the helm chart

### DIFF
--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -31,6 +31,10 @@ spec:
       tolerations:
         {{- toYaml . | trim | nindent 8 }}
       {{- end }}
+      {{- with .Values.flannel.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: flannel
       initContainers:
       - name: install-cni-plugin

--- a/chart/kube-flannel/tests/daemonset_test.yaml
+++ b/chart/kube-flannel/tests/daemonset_test.yaml
@@ -73,3 +73,12 @@ tests:
           content:
             name: install-cni
           any: true
+
+  - it: should render nodeSelector when set
+    set:
+      flannel.nodeSelector:
+        eks.amazonaws.com/compute-type: hybrid
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector["eks.amazonaws.com/compute-type"]
+          value: hybrid

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -91,6 +91,7 @@ flannel:
     operator: Exists
   - effect: NoSchedule
     operator: Exists
+  nodeSelector: {}
 
 netpol:
   enabled: false


### PR DESCRIPTION
## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

Add the ability to specify a nodeSelector in the helm chart. This is useful for situations where you might be doing multicloud and want to have split CNI. For example, a user can then tell the daemonset to only run on non-aws nodes (eg: eks.amazonaws.com/compute-type: hybrid)


## Todos
- [x] Tests
- [x] Documentation
- [x] Release note

## Release Note

```release-note
Added the option for nodeSelector to the helm chart 
```
