### PR TITLE
Add ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -1,0 +1,19 @@
+# Flannel Adopters
+
+This document lists organizations known to use Flannel in production or development/testing environments.
+
+To add your organization to this list, please open a pull request.
+
+## Production Adopters
+
+| Organization | Usage | More Information |
+|---|---|---|
+| SUSE / Rancher | Default CNI for [K3s](https://k3s.io) lightweight Kubernetes | https://k3s.io |
+| SUSE / Rancher | Default CNI for [RKE2](https://docs.rke2.io) Kubernetes distribution | https://docs.rke2.io |
+| Tigera | Used as the networking layer in the [Canal](https://github.com/projectcalico/calico) CNI plugin (Flannel + Calico policy) | https://projectcalico.docs.tigera.io |
+
+## Development / Testing Adopters
+
+| Organization | Usage | More Information |
+|---|---|---|
+| CNCF | Used in various local Kubernetes development environments and CI pipelines | — |


### PR DESCRIPTION
List known production adopters of Flannel including K3s, RKE2, and Canal.