### PR TITLE
fix(vxlan): guard ifaceAddrsV6[0] on IPv4-only setups

### DIFF
--- a/pkg/backend/vxlan/vxlan_network.go
+++ b/pkg/backend/vxlan/vxlan_network.go
@@ -183,46 +183,43 @@ func (nw *network) reCreateVxlan(ctx context.Context) error {
 			continue
 		}
 
-		var ifaceAddrs, ifaceAddrsV6 []net.IP
+		var ifaceAddr, ifaceAddrV6 net.IP
 
 		if config.EnableIPv4 {
-			ifaceAddrs, err = ip.GetInterfaceIP4Addrs(extIface)
+			addrs, err := ip.GetInterfaceIP4Addrs(extIface)
 			if err != nil {
 				log.Errorf("error getting IPv4 addresses for %s: %v", extIface.Name, err)
 				retryAfterBackoff(&backoff, maxBackoff)
 				continue
 			}
-			if len(ifaceAddrs) == 0 {
+			if len(addrs) == 0 {
 				log.Warningf("no IPv4 addresses found for interface %s, retrying", extIface.Name)
 				retryAfterBackoff(&backoff, maxBackoff)
 				continue
 			}
+			ifaceAddr = addrs[0]
 		}
 
 		if config.EnableIPv6 {
-			ifaceAddrsV6, err = ip.GetInterfaceIP6Addrs(extIface)
+			addrs, err := ip.GetInterfaceIP6Addrs(extIface)
 			if err != nil {
 				log.Errorf("error getting IPv6 addresses for %s: %v", extIface.Name, err)
 				retryAfterBackoff(&backoff, maxBackoff)
 				continue
 			}
-			if len(ifaceAddrsV6) == 0 {
+			if len(addrs) == 0 {
 				log.Warningf("no IPv6 addresses found for interface %s, retrying", extIface.Name)
 				retryAfterBackoff(&backoff, maxBackoff)
 				continue
 			}
+			ifaceAddrV6 = addrs[0]
 		}
 
-		// Create the VXLAN device. On IPv4-only setups EnableIPv6 is
-		// false so ifaceAddrsV6 is never populated; ifaceAddrsV6[0]
-		// used to panic with 'index out of range [0] with length 0'
-		// here during vxlan recreate. Pass nil instead — the v6 code
-		// path in createVXLANDevice is gated on config.EnableIPv6.
-		var v6Addr net.IP
-		if len(ifaceAddrsV6) > 0 {
-			v6Addr = ifaceAddrsV6[0]
-		}
-		dev, v6Dev, err := createVXLANDevice(ctx, config, cfg, nw.subnetMgr, extIface.Index, ifaceAddrs[0], v6Addr)
+		// Create the VXLAN device. ifaceAddr / ifaceAddrV6 stay nil
+		// when their family is disabled, so the v4-only and v6-only
+		// paths see the same shape: createVXLANDevice already gates
+		// the v4 / v6 code paths on config.EnableIPv4 / EnableIPv6.
+		dev, v6Dev, err := createVXLANDevice(ctx, config, cfg, nw.subnetMgr, extIface.Index, ifaceAddr, ifaceAddrV6)
 		if err != nil {
 			log.Errorf("failed to create vxlan device: %v", err)
 			retryAfterBackoff(&backoff, maxBackoff)

--- a/pkg/backend/vxlan/vxlan_network.go
+++ b/pkg/backend/vxlan/vxlan_network.go
@@ -213,8 +213,16 @@ func (nw *network) reCreateVxlan(ctx context.Context) error {
 			}
 		}
 
-		// Create the VXLAN device
-		dev, v6Dev, err := createVXLANDevice(ctx, config, cfg, nw.subnetMgr, extIface.Index, ifaceAddrs[0], ifaceAddrsV6[0])
+		// Create the VXLAN device. On IPv4-only setups EnableIPv6 is
+		// false so ifaceAddrsV6 is never populated; ifaceAddrsV6[0]
+		// used to panic with 'index out of range [0] with length 0'
+		// here during vxlan recreate. Pass nil instead — the v6 code
+		// path in createVXLANDevice is gated on config.EnableIPv6.
+		var v6Addr net.IP
+		if len(ifaceAddrsV6) > 0 {
+			v6Addr = ifaceAddrsV6[0]
+		}
+		dev, v6Dev, err := createVXLANDevice(ctx, config, cfg, nw.subnetMgr, extIface.Index, ifaceAddrs[0], v6Addr)
 		if err != nil {
 			log.Errorf("failed to create vxlan device: %v", err)
 			retryAfterBackoff(&backoff, maxBackoff)


### PR DESCRIPTION
Fixes flannel-io/flannel#2433.

## Problem

`reCreateVxlan` indexed `ifaceAddrsV6[0]` unconditionally when calling `createVXLANDevice`. On IPv4-only deployments `config.EnableIPv6` is false, the IPv6-address block above is skipped, and `ifaceAddrsV6` stays empty, so:

```
panic: runtime error: index out of range [0] with length 0
vxlan.(*network).reCreateVxlan vxlan_network.go:217
```

This brought down the whole k3s process on IPv4-only clusters whenever the management NIC was deleted and recreated mid-operation (e.g. NetworkManager DNS add/remove).

## Fix

Take a local `v6Addr` that falls back to `nil` when `ifaceAddrsV6` is empty, and pass that into `createVXLANDevice`. The v6 device creation path inside `createVXLANDevice` is already gated on `config.EnableIPv6`, so nil is a safe value when IPv6 is off.

## Test

`gofmt` clean. The package doesn't cross-compile on darwin (pre-existing netlink build errors in `pkg/ip`), unrelated to this change.