### PR TITLE
fix: reap orphaned zombie child processes when running as PID 1

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -28,7 +28,7 @@ RUN export GOOS=$(xx-info os) &&\
     make dist/flanneld
 RUN git clone https://github.com/kubernetes-sigs/iptables-wrappers.git /iptables-wrapper
 WORKDIR /iptables-wrapper
-RUN git checkout 5792812d9e5a5bb7f22d79d557bbfeece253343d
+RUN git checkout bfef9e5087a198b50a4124bb9ce9d2c7c99025dd
 RUN export GOOS=$(xx-info os) &&\
     export GOARCH=$(xx-info arch) &&\
     export ARCH=$(xx-info arch) &&\
@@ -40,12 +40,11 @@ RUN apk add --no-cache iproute2 ca-certificates nftables iptables strongswan ipt
 RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY --from=flannel-builder /build/dist/flanneld /opt/bin/flanneld
 COPY dist/mk-docker-opts.sh /opt/bin/
-COPY --from=flannel-builder /iptables-wrapper/iptables-wrapper-installer.sh /
-COPY --from=flannel-builder /iptables-wrapper/bin/iptables-wrapper /
+COPY --from=flannel-builder /iptables-wrapper/bin/iptables-wrapper /usr/sbin
 # check manually that iptables-legacy and iptables-nft are present since
 # iptables-wrapper-installer.sh sanity check doesn't work for multi-arch build
 RUN which iptables-legacy && which iptables-nft
-RUN /iptables-wrapper-installer.sh --no-sanity-check
+RUN /usr/sbin/iptables-wrapper install
 
 
 ENTRYPOINT ["/opt/bin/flanneld"]


### PR DESCRIPTION
## Description

**Problem:** flanneld doesn't reap orphaned child processes when running as PID 1 in a container. The iptables-wrapper v2 shell script's nft/legacy auto-detection spawns a `timeout` command whose internal helper process gets orphaned and reparented to flanneld. Since Go's runtime only reaps processes it directly started, this orphan becomes a permanent zombie (`[timeout] <defunct>`).

This results in exactly one zombie process per node that:
- Persists for the lifetime of the container
- Reappears after DaemonSet restart
- Cannot be killed (it's already dead, just not reaped)
- Gets flagged by security audits and monitoring tools

**Fix:** Update iptables-wrapper from v2 to v3. The v3 wrapper is rewritten as a Go binary that uses `exec` instead of a shell script with `timeout`, so no child process is forked and no zombie is created.

**Components affected:**
- `images/Dockerfile` — updates iptables-wrapper to v3 (`bfef9e5`), removes `iptables-wrapper-installer.sh`, uses new install command

**Testing:**
- Manual: deployed patched flanneld to RKE2 cluster, verified `ps aux | grep defunct` returns no results
- Manual: restarted Flannel DaemonSet, confirmed no zombie reappears
- Build: `go build` and `go vet` pass cleanly

## Todos
- [x] Tests
- [ ] Documentation
- [x] Release note

## Release Note

Update iptables-wrapper from v2 to v3 to fix zombie child process (`[timeout] <defunct>`) created during nft/legacy auto-detection when flanneld runs as PID 1.