### PR TITLE
feature(chart): Allow configuring labels and annotations

### DIFF
--- a/chart/kube-flannel/templates/_helpers.tpl
+++ b/chart/kube-flannel/templates/_helpers.tpl
@@ -1,0 +1,8 @@
+{{/* Labels common to all resources */}}
+{{- define "flannel.labels" -}}
+app: {{ .Chart.Name | quote }}
+tier: node
+{{- with .Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
+{{- end -}}

--- a/chart/kube-flannel/templates/_helpers.tpl
+++ b/chart/kube-flannel/templates/_helpers.tpl
@@ -4,9 +4,6 @@
 
 {{- define "flannel.selectorLabels" -}}
 app: "flannel"
-tier: "node"
-app.kubernetes.io/name: {{ include "flannel.name" . }}
-app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 
 {{- define "flannel.chart" -}}
@@ -15,9 +12,12 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{/* Labels common to all resources */}}
 {{- define "flannel.labels" -}}
+tier: "node"
 helm.sh/chart: {{ include "flannel.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/name: {{ include "flannel.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name | trunc 63 | trimSuffix "-" }}
 {{ include "flannel.selectorLabels" . }}
 {{- with .Values.global.commonLabels }}
 {{ toYaml . }}

--- a/chart/kube-flannel/templates/_helpers.tpl
+++ b/chart/kube-flannel/templates/_helpers.tpl
@@ -1,10 +1,23 @@
+{{- define "flannel.name" -}}
+{{- .Chart.Name  | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
 {{- define "flannel.selectorLabels" -}}
 app: "flannel"
 tier: "node"
+app.kubernetes.io/name: {{ include "flannel.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{- define "flannel.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
 
 {{/* Labels common to all resources */}}
 {{- define "flannel.labels" -}}
+helm.sh/chart: {{ include "flannel.chart" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ include "flannel.selectorLabels" . }}
 {{- with .Values.global.commonLabels }}
 {{ toYaml . }}

--- a/chart/kube-flannel/templates/_helpers.tpl
+++ b/chart/kube-flannel/templates/_helpers.tpl
@@ -1,8 +1,12 @@
+{{- define "flannel.selectorLabels" -}}
+app: "flannel"
+tier: "node"
+{{- end -}}
+
 {{/* Labels common to all resources */}}
 {{- define "flannel.labels" -}}
-app: {{ .Chart.Name | quote }}
-tier: node
+{{ include "flannel.selectorLabels" . }}
 {{- with .Values.global.commonLabels }}
 {{ toYaml . }}
-{{- end }}
+{{- end -}}
 {{- end -}}

--- a/chart/kube-flannel/templates/config.yaml
+++ b/chart/kube-flannel/templates/config.yaml
@@ -6,6 +6,13 @@ metadata:
   labels:
     tier: node
     app: flannel
+    {{- with merge .Values.flannel.configMap.labels .Values.global.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with merge .Values.flannel.configMap.annotations .Values.global.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 data:
   cni-conf.json: {{ .Values.flannel.cniConf | toJson }}
   net-conf.json: |

--- a/chart/kube-flannel/templates/config.yaml
+++ b/chart/kube-flannel/templates/config.yaml
@@ -4,9 +4,8 @@ metadata:
   name: kube-flannel-cfg
   namespace: {{ .Release.Namespace }}
   labels:
-    tier: node
-    app: flannel
-    {{- with merge .Values.flannel.configMap.labels .Values.global.commonLabels }}
+    {{- include "flannel.labels" . | nindent 4 }}
+    {{- with .Values.flannel.configMap.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- with merge .Values.flannel.configMap.annotations .Values.global.commonAnnotations }}

--- a/chart/kube-flannel/templates/config.yaml
+++ b/chart/kube-flannel/templates/config.yaml
@@ -3,11 +3,10 @@ apiVersion: v1
 metadata:
   name: kube-flannel-cfg
   namespace: {{ .Release.Namespace }}
+  {{- with (merge .Values.flannel.configMap.labels (include "flannel.labels" . | fromYaml)) }}
   labels:
-    {{- include "flannel.labels" . | nindent 4 }}
-    {{- with .Values.flannel.configMap.labels }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
   {{- with merge .Values.flannel.configMap.annotations .Values.global.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -6,6 +6,13 @@ metadata:
   labels:
     tier: node
     app: flannel
+    {{- with merge .Values.flannel.daemonSet.labels .Values.global.commonLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with merge .Values.flannel.daemonSet.annotations .Values.global.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -15,6 +22,13 @@ spec:
       labels:
         tier: node
         app: flannel
+        {{- with merge .Values.flannel.podLabels .Values.global.commonLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with merge .Values.flannel.podAnnotations .Values.global.commonAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       affinity:
         nodeAffinity:

--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -4,9 +4,8 @@ metadata:
   name: kube-flannel-ds
   namespace: {{ .Release.Namespace }}
   labels:
-    tier: node
-    app: flannel
-    {{- with merge .Values.flannel.daemonSet.labels .Values.global.commonLabels }}
+    {{- include "flannel.labels" . | nindent 4 }}
+    {{- with .Values.flannel.daemonSet.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- with merge .Values.flannel.daemonSet.annotations .Values.global.commonAnnotations }}
@@ -16,13 +15,12 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: flannel
+      {{- include "flannel.labels" . | nindent 6 }}
   template:
     metadata:
       labels:
-        tier: node
-        app: flannel
-        {{- with merge .Values.flannel.podLabels .Values.global.commonLabels }}
+        {{- include "flannel.labels" . | nindent 8 }}
+        {{- with .Values.flannel.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with merge .Values.flannel.podAnnotations .Values.global.commonAnnotations }}

--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -3,11 +3,10 @@ kind: DaemonSet
 metadata:
   name: kube-flannel-ds
   namespace: {{ .Release.Namespace }}
+  {{- with (merge .Values.flannel.daemonSet.labels (include "flannel.labels" . | fromYaml)) }}
   labels:
-    {{- include "flannel.labels" . | nindent 4 }}
-    {{- with .Values.flannel.daemonSet.labels }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
   {{- with merge .Values.flannel.daemonSet.annotations .Values.global.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -15,14 +14,13 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "flannel.labels" . | nindent 6 }}
+      {{- include "flannel.selectorLabels" . | nindent 6 }}
   template:
     metadata:
+      {{- with (merge .Values.flannel.podLabels (include "flannel.labels" . | fromYaml)) }}
       labels:
-        {{- include "flannel.labels" . | nindent 8 }}
-        {{- with .Values.flannel.podLabels }}
         {{- toYaml . | nindent 8 }}
-        {{- end }}
+      {{- end }}
       {{- with merge .Values.flannel.podAnnotations .Values.global.commonAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}

--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -17,7 +17,7 @@ spec:
       {{- include "flannel.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with (merge .Values.flannel.podLabels (include "flannel.labels" . | fromYaml)) }}
+      {{- with (merge (include "flannel.labels" . | fromYaml) .Values.flannel.podLabels) }}
       labels:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/chart/kube-flannel/templates/rbac.yaml
+++ b/chart/kube-flannel/templates/rbac.yaml
@@ -3,7 +3,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
   labels:
-    {{- with (merge .Values.flannel.rbac.clusterRole.labels .Values.flannel.rbac.labels .Values.global.commonLabels) }}
+    {{- include "flannel.labels" . | nindent 4 }}
+    {{- with (merge .Values.flannel.rbac.clusterRole.labels .Values.flannel.rbac.labels) }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- with (merge .Values.flannel.rbac.clusterRole.annotations .Values.flannel.rbac.annotations .Values.global.commonAnnotations) }}
@@ -50,7 +51,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
   labels:
-    {{- with (merge .Values.flannel.rbac.clusterRoleBinding.labels .Values.flannel.rbac.labels .Values.global.commonLabels) }}
+    {{- include "flannel.labels" . | nindent 4 }}
+    {{- with (merge .Values.flannel.rbac.clusterRoleBinding.labels .Values.flannel.rbac.labels) }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- with (merge .Values.flannel.rbac.clusterRoleBinding.annotations .Values.flannel.rbac.annotations .Values.global.commonAnnotations) }}

--- a/chart/kube-flannel/templates/rbac.yaml
+++ b/chart/kube-flannel/templates/rbac.yaml
@@ -2,6 +2,14 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
+  labels:
+    {{- with (merge .Values.flannel.rbac.clusterRole.labels .Values.flannel.rbac.labels .Values.global.commonLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with (merge .Values.flannel.rbac.clusterRole.annotations .Values.flannel.rbac.annotations .Values.global.commonAnnotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups:
   - ""
@@ -41,6 +49,14 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
+  labels:
+    {{- with (merge .Values.flannel.rbac.clusterRoleBinding.labels .Values.flannel.rbac.labels .Values.global.commonLabels) }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with (merge .Values.flannel.rbac.clusterRoleBinding.annotations .Values.flannel.rbac.annotations .Values.global.commonAnnotations) }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/chart/kube-flannel/templates/rbac.yaml
+++ b/chart/kube-flannel/templates/rbac.yaml
@@ -2,11 +2,10 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
+  {{- with (merge .Values.flannel.rbac.clusterRole.labels .Values.flannel.rbac.labels (include "flannel.labels" . | fromYaml)) }}
   labels:
-    {{- include "flannel.labels" . | nindent 4 }}
-    {{- with (merge .Values.flannel.rbac.clusterRole.labels .Values.flannel.rbac.labels) }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
   {{- with (merge .Values.flannel.rbac.clusterRole.annotations .Values.flannel.rbac.annotations .Values.global.commonAnnotations) }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -50,9 +49,8 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: flannel
+  {{- with (merge .Values.flannel.rbac.clusterRoleBinding.labels .Values.flannel.rbac.labels (include "flannel.labels" . | fromYaml)) }}
   labels:
-    {{- include "flannel.labels" . | nindent 4 }}
-    {{- with (merge .Values.flannel.rbac.clusterRoleBinding.labels .Values.flannel.rbac.labels) }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
   {{- with (merge .Values.flannel.rbac.clusterRoleBinding.annotations .Values.flannel.rbac.annotations .Values.global.commonAnnotations) }}

--- a/chart/kube-flannel/templates/serviceaccount.yaml
+++ b/chart/kube-flannel/templates/serviceaccount.yaml
@@ -3,3 +3,11 @@ kind: ServiceAccount
 metadata:
   name: flannel
   namespace: {{ .Release.Namespace }}
+  {{- with merge .Values.flannel.serviceAccount.labels .Values.global.commonLabels }}
+  labels:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with merge .Values.flannel.serviceAccount.annotations .Values.global.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}

--- a/chart/kube-flannel/templates/serviceaccount.yaml
+++ b/chart/kube-flannel/templates/serviceaccount.yaml
@@ -3,10 +3,11 @@ kind: ServiceAccount
 metadata:
   name: flannel
   namespace: {{ .Release.Namespace }}
-  {{- with merge .Values.flannel.serviceAccount.labels .Values.global.commonLabels }}
   labels:
+    {{- include "flannel.labels" . | nindent 4 }}
+    {{- with .Values.flannel.serviceAccount.labels }}
     {{- toYaml . | nindent 4 }}
-  {{- end }}
+    {{- end }}
   {{- with merge .Values.flannel.serviceAccount.annotations .Values.global.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/kube-flannel/templates/serviceaccount.yaml
+++ b/chart/kube-flannel/templates/serviceaccount.yaml
@@ -3,11 +3,10 @@ kind: ServiceAccount
 metadata:
   name: flannel
   namespace: {{ .Release.Namespace }}
+    {{- with (merge .Values.flannel.serviceAccount.labels (include "flannel.labels" . | fromYaml)) }}
   labels:
-    {{- include "flannel.labels" . | nindent 4 }}
-    {{- with .Values.flannel.serviceAccount.labels }}
     {{- toYaml . | nindent 4 }}
-    {{- end }}
+  {{- end }}
   {{- with merge .Values.flannel.serviceAccount.annotations .Values.global.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/chart/kube-flannel/tests/labels_annotations_override_test.yaml
+++ b/chart/kube-flannel/tests/labels_annotations_override_test.yaml
@@ -68,14 +68,14 @@ tests:
     set:
       flannel.rbac.labels:
         rbac-non-overridden-label: "rbac label should not be overridden"
-        rbac-overrridden-label: "rbac label should be overridden"
+        rbac-overridden-label: "rbac label should be overridden"
       flannel.rbac.clusterRole.labels:
         rbac-overridden-label: "rbac label has been overridden"
       flannel.rbac.clusterRoleBinding.labels:
         rbac-overridden-label: "rbac label has been overridden"
       flannel.rbac.annotations:
         rbac-non-overridden-annotation: "rbac annotation should not be overridden"
-        rbac-overrridden-annotation: "rbac annotation should be overridden"
+        rbac-overridden-annotation: "rbac annotation should be overridden"
       flannel.rbac.clusterRole.annotations:
         rbac-overridden-annotation: "rbac annotation has been overridden"
       flannel.rbac.clusterRoleBinding.annotations:
@@ -93,3 +93,30 @@ tests:
       - equal:
           path: metadata.annotations.rbac-overridden-annotation
           value: "rbac annotation has been overridden"
+  - it: selector.matchLabels must not change (helm upgrade is immutable)
+    templates:
+      - daemonset.yaml
+    set:
+      global.commonLabels:
+        should-not-appear-selector: "selector labels should not change"
+      flannel.podLabels:
+        should-not-appear-selector: "selector labels should not change"
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app: flannel
+  - it: selector labels should not be overridden by user
+    templates:
+      - daemonset.yaml
+    set:
+      flannel.podLabels:
+        app: "user tries to override selector label"
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app: flannel
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: "flannel"

--- a/chart/kube-flannel/tests/labels_annotations_override_test.yaml
+++ b/chart/kube-flannel/tests/labels_annotations_override_test.yaml
@@ -1,0 +1,95 @@
+suite: test labels annotations overrides
+templates:
+  - daemonset.yaml
+  - rbac.yaml
+  - serviceaccount.yaml
+  - config.yaml
+tests:
+  - it: should have the correct labels and annotations for overrides
+    set:
+      global.commonLabels:
+        non-overridden-label: "label should not be overridden"
+        overridden-label: "label has not been overridden"
+      global.commonAnnotations:
+        non-overridden-annotation: "annotation should not be overridden"
+        overridden-annotation: "annotation has not been overridden"
+      flannel.configMap.labels:
+        overridden-label: "label has been overridden"
+        leaf-label: "label has been set at the leaf level" # Leaf as in the individual templates
+      flannel.configMap.annotations:
+        overridden-annotation: "annotation has been overridden"
+        leaf-annotation: "annotation has been set at the leaf level"
+      flannel.daemonSet.labels:
+        overridden-label: "label has been overridden"
+        leaf-label: "label has been set at the leaf level"
+      flannel.daemonSet.annotations:
+        overridden-annotation: "annotation has been overridden"
+        leaf-annotation: "annotation has been set at the leaf level"
+      flannel.rbac.clusterRole.labels:
+        overridden-label: "label has been overridden"
+        leaf-label: "label has been set at the leaf level"
+      flannel.rbac.clusterRole.annotations:
+        overridden-annotation: "annotation has been overridden"
+        leaf-annotation: "annotation has been set at the leaf level"
+      flannel.rbac.clusterRoleBinding.labels:
+        overridden-label: "label has been overridden"
+        leaf-label: "label has been set at the leaf level"
+      flannel.rbac.clusterRoleBinding.annotations:
+        overridden-annotation: "annotation has been overridden"
+        leaf-annotation: "annotation has been set at the leaf level"
+      flannel.serviceAccount.labels:
+        overridden-label: "label has been overridden"
+        leaf-label: "label has been set at the leaf level"
+      flannel.serviceAccount.annotations:
+        overridden-annotation: "annotation has been overridden"
+        leaf-annotation: "annotation has been set at the leaf level"
+    asserts:
+      - equal:
+          path: metadata.labels.non-overridden-label
+          value: "label should not be overridden"
+      - equal:
+          path: metadata.labels.overridden-label
+          value: "label has been overridden"
+      - equal:
+          path: metadata.labels.leaf-label
+          value: "label has been set at the leaf level"
+      - equal:
+          path: metadata.annotations.non-overridden-annotation
+          value: "annotation should not be overridden"
+      - equal:
+          path: metadata.annotations.overridden-annotation
+          value: "annotation has been overridden"
+      - equal:
+          path: metadata.annotations.leaf-annotation
+          value: "annotation has been set at the leaf level"
+  - it: should have the correct labels and annotations for rbac overrides
+    templates:
+      - rbac.yaml
+    set:
+      flannel.rbac.labels:
+        rbac-non-overridden-label: "rbac label should not be overridden"
+        rbac-overrridden-label: "rbac label should be overridden"
+      flannel.rbac.clusterRole.labels:
+        rbac-overridden-label: "rbac label has been overridden"
+      flannel.rbac.clusterRoleBinding.labels:
+        rbac-overridden-label: "rbac label has been overridden"
+      flannel.rbac.annotations:
+        rbac-non-overridden-annotation: "rbac annotation should not be overridden"
+        rbac-overrridden-annotation: "rbac annotation should be overridden"
+      flannel.rbac.clusterRole.annotations:
+        rbac-overridden-annotation: "rbac annotation has been overridden"
+      flannel.rbac.clusterRoleBinding.annotations:
+        rbac-overridden-annotation: "rbac annotation has been overridden"
+    asserts:
+      - equal:
+          path: metadata.labels.rbac-non-overridden-label
+          value: "rbac label should not be overridden"
+      - equal:
+          path: metadata.labels.rbac-overridden-label
+          value: "rbac label has been overridden"
+      - equal:
+          path: metadata.annotations.rbac-non-overridden-annotation
+          value: "rbac annotation should not be overridden"
+      - equal:
+          path: metadata.annotations.rbac-overridden-annotation
+          value: "rbac annotation has been overridden"

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -2,6 +2,10 @@
 global:
   imagePullSecrets:
 # - name: "a-secret-name"
+  # Labels to be applied to all deployed resources
+  commonLabels: {}
+  # Annotations to be applied to all deployed resources
+  commonAnnotations: {}
 
 # The IPv4 cidr pool to create on startup if none exists. Pod IPs will be
 # chosen from this range.
@@ -35,7 +39,7 @@ flannel:
   backend: "vxlan"
   # Port used by the backend 0 means default value (VXLAN: 8472, Wireguard: 51821, UDP: 8285)
   #backendPort: 0
-  # MTU to use for outgoing packets (VXLAN and Wiregurad) if not defined the MTU of the external interface is used.
+  # MTU to use for outgoing packets (VXLAN and WireGuard) if not defined the MTU of the external interface is used.
   # mtu: 1500
   #
   # VXLAN Configs:
@@ -49,13 +53,13 @@ flannel:
   # MAC prefix to be used on Windows. (Defaults is 0E-2A)
   # macPrefix: "0E-2A"
   #
-  # Wireguard Configs:
+  # WireGuard Configs:
   #
   # UDP listen port used with IPv6
   # backendPortv6: 51821
   # Pre shared key to use
   # psk: 0
-  # IP version to use on Wireguard
+  # IP version to use on WireGuard
   # tunnelMode: "separate"
   # Persistent keep interval to use
   # keepaliveInterval: 0
@@ -103,6 +107,46 @@ flannel:
   - effect: NoSchedule
     operator: Exists
   nodeSelector: {}
+
+  configMap:
+    # Additional labels to add to the ConfigMap
+    labels: {}
+    # Additional annotations to add to the ConfigMap
+    annotations: {}
+
+  # Labels to be applied to the deployed pods
+  podLabels: {}
+  # Annotations to be applied to the deployed pods
+  podAnnotations: {}
+
+  daemonSet:
+    # Additional labels to add to the DaemonSet
+    labels: {}
+    # Additional annotations to add to the DaemonSet
+    annotations: {}
+
+  serviceAccount:
+    # Additional labels to add to the service account
+    labels: {}
+    # Additional annotations to add to the service account
+    annotations: {}
+
+  rbac:
+    # Additional labels to add to all RBAC-related resources
+    labels: {}
+    # Additional annotations to add to all RBAC-related resources
+    annotations: {}
+    clusterRole:
+      # Additional labels to add to the ClusterRole
+      labels: {}
+      # Additional annotations to add to the ClusterRole
+      annotations: {}
+    clusterRoleBinding:
+      # Additional labels to add to the ClusterRoleBinding
+      labels: {}
+      # Additional annotations to add to the ClusterRoleBinding
+      annotations: {}
+
 
 netpol:
   enabled: false


### PR DESCRIPTION
lets users configure the labels and annotations in the Helm chart

Resolves #2442

## Description
Feature for the Helm chart that lets users modify the labels and annotations of deployed resources.

## Todos
- [x] Tests
- [x] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
