### PR TITLE
fix: skip invalid CIDRs in subnet file readers

### DIFF
--- a/main.go
+++ b/main.go
@@ -608,6 +608,7 @@ func ReadCIDRsFromSubnetFile(path string, CIDRKey string) []ip.IP4Net {
 				_, cidr, err := net.ParseCIDR(cidrs[i])
 				if err != nil {
 					log.Errorf("Couldn't parse previous %s from subnet file at %s: %s", CIDRKey, path, err)
+					continue
 				}
 				prevCIDRs = append(prevCIDRs, ip.FromIPNet(cidr))
 			}
@@ -643,6 +644,7 @@ func ReadIP6CIDRsFromSubnetFile(path string, CIDRKey string) []ip.IP6Net {
 				_, cidr, err := net.ParseCIDR(cidrs[i])
 				if err != nil {
 					log.Errorf("Couldn't parse previous %s from subnet file at %s: %s", CIDRKey, path, err)
+					continue
 				}
 				prevCIDRs = append(prevCIDRs, ip.FromIP6Net(cidr))
 			}

--- a/main_test.go
+++ b/main_test.go
@@ -1,3 +1,17 @@
+// Copyright 2026 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package main
 
 import (

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/flannel-io/flannel/pkg/ip"
+)
+
+func TestReadCIDRsFromSubnetFileSkipsInvalidCIDRs(t *testing.T) {
+	path := writeSubnetFile(t, "FLANNEL_SUBNET=10.244.1.0/24,not-a-cidr,10.244.2.0/24\n")
+
+	defer assertNotPanics(t)()
+
+	got := ReadCIDRsFromSubnetFile(path, "FLANNEL_SUBNET")
+	want := []ip.IP4Net{
+		mustParseIP4Net(t, "10.244.1.0/24"),
+		mustParseIP4Net(t, "10.244.2.0/24"),
+	}
+
+	assertIP4NetsEqual(t, got, want)
+}
+
+func TestReadIP6CIDRsFromSubnetFileSkipsInvalidCIDRs(t *testing.T) {
+	path := writeSubnetFile(t, "FLANNEL_IPV6_SUBNET=fd00::/64,not-a-cidr,fd01::/64\n")
+
+	defer assertNotPanics(t)()
+
+	got := ReadIP6CIDRsFromSubnetFile(path, "FLANNEL_IPV6_SUBNET")
+	want := []ip.IP6Net{
+		mustParseIP6Net(t, "fd00::/64"),
+		mustParseIP6Net(t, "fd01::/64"),
+	}
+
+	assertIP6NetsEqual(t, got, want)
+}
+
+func TestReadCIDRFromSubnetFileInvalidOnlyReturnsEmpty(t *testing.T) {
+	path := writeSubnetFile(t, "FLANNEL_SUBNET=not-a-cidr\n")
+
+	defer assertNotPanics(t)()
+
+	got := ReadCIDRFromSubnetFile(path, "FLANNEL_SUBNET")
+	if !got.Empty() {
+		t.Fatalf("expected empty ipv4 subnet, got %s", got)
+	}
+}
+
+func TestReadIP6CIDRFromSubnetFileInvalidOnlyReturnsEmpty(t *testing.T) {
+	path := writeSubnetFile(t, "FLANNEL_IPV6_SUBNET=not-a-cidr\n")
+
+	defer assertNotPanics(t)()
+
+	got := ReadIP6CIDRFromSubnetFile(path, "FLANNEL_IPV6_SUBNET")
+	if !got.Empty() {
+		t.Fatalf("expected empty ipv6 subnet, got %s", got)
+	}
+}
+
+func writeSubnetFile(t *testing.T, contents string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "subnet.env")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("write subnet file: %v", err)
+	}
+
+	return path
+}
+
+func assertNotPanics(t *testing.T) func() {
+	t.Helper()
+
+	return func() {
+		t.Helper()
+		if r := recover(); r != nil {
+			t.Fatalf("unexpected panic: %v", r)
+		}
+	}
+}
+
+func mustParseIP4Net(t *testing.T, cidr string) ip.IP4Net {
+	t.Helper()
+
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("parse ipv4 cidr %q: %v", cidr, err)
+	}
+
+	return ip.FromIPNet(network)
+}
+
+func mustParseIP6Net(t *testing.T, cidr string) ip.IP6Net {
+	t.Helper()
+
+	_, network, err := net.ParseCIDR(cidr)
+	if err != nil {
+		t.Fatalf("parse ipv6 cidr %q: %v", cidr, err)
+	}
+
+	return ip.FromIP6Net(network)
+}
+
+func assertIP4NetsEqual(t *testing.T, got, want []ip.IP4Net) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("unexpected ipv4 cidr count: got %d want %d", len(got), len(want))
+	}
+
+	for i := range want {
+		if !got[i].Equal(want[i]) {
+			t.Fatalf("unexpected ipv4 cidr at index %d: got %s want %s", i, got[i], want[i])
+		}
+	}
+}
+
+func assertIP6NetsEqual(t *testing.T, got, want []ip.IP6Net) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("unexpected ipv6 cidr count: got %d want %d", len(got), len(want))
+	}
+
+	for i := range want {
+		if !got[i].Equal(want[i]) {
+			t.Fatalf("unexpected ipv6 cidr at index %d: got %s want %s", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Description
bug fix in the subnet file readers in `main.go`.

if `/run/flannel/subnet.env` has a bad CIDR, flanneld logs the parse error and then still dereferences the nil `*net.IPNet`, so startup blows up. pretty easy little footgun.

This just skips invalid CIDR entries and keeps the valid ones. if the file is all junk, flannel falls back to the existing empty-subnet path instead of panicking.

Repro:
```bash
cat >/tmp/subnet.env <<'EOF'
FLANNEL_SUBNET=10.244.1.0/24,not-a-cidr,10.244.2.0/24
EOF

flanneld --subnet-file=/tmp/subnet.env
```
old behavior: panic in `ip.FromIPNet()`
new behavior: log the bad CIDR, keep going

Testing:
- `go test ./... -run 'TestRead(CIDR|CIDRs|IP6CIDR|IP6CIDRs)FromSubnetFile'`
- `go test ./... -run 'TestDoesNotExist'`
- reproduced the old crash with a tiny `go run` repro using the pre-fix reader code

Related-ish: #2437 is another `subnet.env` startup edge case, this one is a different path though

## Todos
- [x] Tests
- [ ] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```
