### PR TITLE
feat: new install_conf cmd to install flannel's config file

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -146,9 +146,8 @@ spec:
       - name: install-cni
         image: ghcr.io/flannel-io/flannel:v0.28.5
         command:
-        - cp
+        - /opt/bin/install-conf
         args:
-        - -f
         - /etc/kube-flannel/cni-conf.json
         - /etc/cni/net.d/10-flannel.conflist
         volumeMounts:

--- a/cmd/install_conf/main.go
+++ b/cmd/install_conf/main.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2026 Flannel Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is a install tool for multus plugins
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/flannel-io/flannel/pkg/utils"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintf(os.Stderr, "usage: %s <src> <dest>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	src := os.Args[1]
+	dest := os.Args[2]
+	destDir := filepath.Dir(dest)
+	destFileName := filepath.Base(dest)
+
+	if err := utils.CopyFileAtomic(src, destDir, "."+destFileName+".tmp", destFileName); err != nil {
+		fmt.Fprintf(os.Stderr, "error installing %q: %v\n", src, err)
+		os.Exit(1)
+	}
+}

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -15,6 +15,7 @@ RUN set -x && \
 FROM --platform=$BUILDPLATFORM base-builder AS flannel-builder
 COPY Makefile go.mod go.sum *.go /build/
 COPY pkg /build/pkg
+COPY cmd /build/cmd
 WORKDIR /build
 RUN mkdir dist
 RUN go mod download
@@ -26,6 +27,9 @@ RUN export GOOS=$(xx-info os) &&\
     export GOARCH=$(xx-info arch) &&\
     export ARCH=$(xx-info arch) &&\
     make dist/flanneld
+RUN export GOOS=$(xx-info os) &&\
+    export GOARCH=$(xx-info arch) &&\
+    CGO_ENABLED=0 go build -o dist/install-conf ./cmd/install_conf/
 RUN git clone https://github.com/kubernetes-sigs/iptables-wrappers.git /iptables-wrapper
 WORKDIR /iptables-wrapper
 RUN git checkout bfef9e5087a198b50a4124bb9ce9d2c7c99025dd
@@ -39,6 +43,7 @@ RUN apk update && apk upgrade
 RUN apk add --no-cache iproute2 ca-certificates nftables iptables strongswan iptables-legacy && update-ca-certificates
 RUN apk add wireguard-tools --no-cache --repository http://dl-cdn.alpinelinux.org/alpine/edge/community
 COPY --from=flannel-builder /build/dist/flanneld /opt/bin/flanneld
+COPY --from=flannel-builder /build/dist/install-conf /opt/bin/install-conf
 COPY dist/mk-docker-opts.sh /opt/bin/
 COPY --from=flannel-builder /iptables-wrapper/bin/iptables-wrapper /usr/sbin
 # check manually that iptables-legacy and iptables-nft are present since

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2026 Flannel Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cmdutils is the package that contains utilities for multus command
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// CopyFileAtomic does file copy atomically
+func CopyFileAtomic(srcFilePath, destDir, tempFileName, destFileName string) error {
+	tempFilePath := filepath.Join(destDir, tempFileName)
+	// check temp filepath and remove old file if exists
+	if _, err := os.Stat(tempFilePath); err == nil {
+		err = os.Remove(tempFilePath)
+		if err != nil {
+			return fmt.Errorf("cannot remove old temp file %q: %v", tempFilePath, err)
+		}
+	}
+
+	// create temp file
+	f, err := os.CreateTemp(destDir, tempFileName)
+	if err != nil {
+		return fmt.Errorf("cannot create temp file %q in %q: %v", tempFileName, destDir, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	srcFile, err := os.Open(srcFilePath)
+	if err != nil {
+		return fmt.Errorf("cannot open file %q: %v", srcFilePath, err)
+	}
+	defer func() { _ = srcFile.Close() }()
+
+	// Copy file to tempfile
+	_, err = io.Copy(f, srcFile)
+	if err != nil {
+		_ = f.Close()
+		_ = os.Remove(tempFilePath)
+		return fmt.Errorf("cannot write data to temp file %q: %v", tempFilePath, err)
+	}
+	if err := f.Sync(); err != nil {
+		return fmt.Errorf("cannot flush temp file %q: %v", tempFilePath, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("cannot close temp file %q: %v", tempFilePath, err)
+	}
+
+	// change file mode if different
+	destFilePath := filepath.Join(destDir, destFileName)
+	_, err = os.Stat(destFilePath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	srcFileStat, err := os.Stat(srcFilePath)
+	if err != nil {
+		return err
+	}
+
+	if err := os.Chmod(f.Name(), srcFileStat.Mode()); err != nil {
+		return fmt.Errorf("cannot set stat on temp file %q: %v", f.Name(), err)
+	}
+
+	// replace file with tempfile
+	if err := os.Rename(f.Name(), destFilePath); err != nil {
+		return fmt.Errorf("cannot replace %q with temp file %q: %v", destFilePath, tempFilePath, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION

## Description
The PR adds a static go binary that can be used to  copy files atomically.
In this way we won't need cp for the init container and we can use a minimal container
esp. downstream where we use k3s-root to get the iptables binary.

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
