### PR TITLE
subnet/etcd: recover subnet watch from compaction

### DIFF
--- a/pkg/subnet/etcd/registry.go
+++ b/pkg/subnet/etcd/registry.go
@@ -293,7 +293,7 @@ func (esr *etcdSubnetRegistry) watchSubnets(ctx context.Context, leaseWatchChan 
 	for {
 		wctx, cancel := context.WithCancel(ctx)
 		defer cancel()
-		log.Infof("registry: watching subnets starting from rev %d", since)
+		log.V(4).Infof("registry: watching subnets starting from rev %d", since)
 		rch := esr.cli.Watch(etcd.WithRequireLeader(wctx), key, etcd.WithPrefix(), etcd.WithRev(since))
 		if rch == nil {
 			log.Errorf("Failed to establish etcd watch channel")
@@ -316,17 +316,35 @@ func (esr *etcdSubnetRegistry) watchSubnets(ctx context.Context, leaseWatchChan 
 			case wresp, ok := <-rch:
 				err := wresp.Err()
 				if !ok || err != nil {
-					if err != nil {
-						log.Warningf("etcd watch channel for %s closed with error %v, reconnecting...", key, err)
-					} else {
-						log.Warningf("etcd watch channel for %s closed, reconnecting...", key)
-					}
 					cancel()
+					// If the watch fell behind etcd's compaction horizon, reconnecting
+					// at the same revision fails identically forever (mvcc: required
+					// revision has been compacted). Re-list to grab a fresh snapshot at
+					// a current revision and resume from there instead of hot-looping.
+					if isCompacted(wresp) {
+						log.Warningf("etcd watch for %s fell behind compaction, re-listing and resuming", key)
+						next, rerr := esr.resyncWatch(ctx, leaseWatchChan)
+						if rerr != nil {
+							log.Errorf("failed to re-list subnets after compaction: %v", rerr)
+							time.Sleep(exponentialBackoff)
+							exponentialBackoff = min(exponentialBackoff*2, maxBackoff)
+							break innerLoop
+						}
+						since = next
+						exponentialBackoff = initialBackoff
+						break innerLoop
+					}
+					log.Warningf("etcd watch channel for %s closed (%v), reconnecting from rev %d...", key, err, since)
 					time.Sleep(exponentialBackoff)
 					exponentialBackoff = min(exponentialBackoff*2, maxBackoff)
 					break innerLoop
 				}
 				exponentialBackoff = initialBackoff // Reset backoff on success
+				// Advance the resume revision so a future reconnect picks up where we
+				// left off rather than replaying from the original start revision.
+				if wresp.Header.Revision != 0 {
+					since = wresp.Header.Revision + 1
+				}
 				results := make([]lease.LeaseWatchResult, 0)
 				for _, etcdEvent := range wresp.Events {
 					subnetEvent, err := parseSubnetWatchResponse(ctx, esr.cli, etcdEvent)
@@ -526,6 +544,25 @@ func kvToIPLease(kv *mvccpb.KeyValue, ttl int64) (*lease.Lease, error) {
 	}
 
 	return &lease, nil
+}
+
+// isCompacted reports whether a watch response failed because its start revision
+// has been compacted away by etcd. Reconnecting at the same revision would fail
+// identically forever, so the caller must re-list at a fresh revision instead.
+func isCompacted(wresp etcd.WatchResponse) bool {
+	return wresp.CompactRevision != 0 || errors.Is(wresp.Err(), rpctypes.ErrCompacted)
+}
+
+// resyncWatch re-lists all subnet leases, emits the fresh snapshot on ch, and
+// returns the revision the caller should resume watching from. Used to recover a
+// watch that has fallen behind etcd's compaction horizon.
+func (esr *etcdSubnetRegistry) resyncWatch(ctx context.Context, ch chan []lease.LeaseWatchResult) (int64, error) {
+	wr, err := esr.leasesWatchReset(ctx)
+	if err != nil {
+		return 0, err
+	}
+	ch <- []lease.LeaseWatchResult{wr}
+	return getNextIndex(wr.Cursor)
 }
 
 // leasesWatchReset is called when incremental lease watch failed and we need to grab a snapshot

--- a/pkg/subnet/etcd/registry_test.go
+++ b/pkg/subnet/etcd/registry_test.go
@@ -216,3 +216,104 @@ func TestEtcdRegistry(t *testing.T) {
 
 	// TODO: watchSubnet and watchNetworks
 }
+
+// TestWatchSubnetsRecoversFromCompaction exercises the case where a subnet watch
+// falls behind etcd's compaction horizon. Before the fix, watchSubnets reconnected
+// at the same now-compacted revision forever (hot-looping on "required revision has
+// been compacted" and never delivering anything). The fix re-lists at a fresh
+// revision and resumes, so the watch must deliver a snapshot followed by live events.
+func TestWatchSubnetsRecoversFromCompaction(t *testing.T) {
+	integration.BeforeTestExternal(t)
+
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	client := clus.RandClient()
+	// Use a non-cancelable context like TestEtcdRegistry: cancelling drives
+	// watchSubnets to Close() the etcd client, which is shared with the test
+	// cluster harness and would break Terminate.
+	ctx := context.Background()
+
+	r, kvApi := newTestEtcdRegistry(t, ctx, client)
+
+	if _, err := kvApi.Put(ctx, "/coreos.com/network/config",
+		`{ "Network": "10.1.0.0/16", "Backend": { "Type": "host-gw" } }`); err != nil {
+		t.Fatal("Failed to put network config", err)
+	}
+
+	// An existing lease so the recovery re-list has something to snapshot.
+	sn := ip.IP4Net{IP: ip.MustParseIP4("10.1.5.0"), PrefixLen: 24}
+	attrs := &lease.LeaseAttrs{PublicIP: ip.MustParseIP4("1.2.3.4")}
+	if _, err := r.createSubnet(ctx, sn, ip.IP6Net{}, attrs, 24*time.Hour); err != nil {
+		t.Fatal("Failed to create subnet lease", err)
+	}
+
+	// Advance the store revision, then compact past it so that watching from an
+	// old revision is guaranteed to hit "required revision has been compacted".
+	var compactRev int64
+	for i := 0; i < 5; i++ {
+		resp, err := kvApi.Put(ctx, "/coreos.com/network/_bump", fmt.Sprintf("%d", i))
+		if err != nil {
+			t.Fatal("Failed to bump revision", err)
+		}
+		compactRev = resp.Header.Revision
+	}
+	if _, err := client.Compact(ctx, compactRev); err != nil {
+		t.Fatal("Failed to compact etcd", err)
+	}
+
+	// Start the watch from rev 1, now below the compaction horizon.
+	receiver := make(chan []lease.LeaseWatchResult, 16)
+	go func() { _ = r.watchSubnets(ctx, receiver, 1) }()
+
+	// Recovery must surface a re-list snapshot that includes the existing lease.
+	if !waitForSnapshot(receiver, sn, 10*time.Second) {
+		t.Fatal("watchSubnets did not recover from compaction with a re-list snapshot")
+	}
+
+	// A live event for a newly created lease proves the watch resumed at a current
+	// revision instead of staying stuck on the compacted one.
+	sn2 := ip.IP4Net{IP: ip.MustParseIP4("10.1.6.0"), PrefixLen: 24}
+	if _, err := r.createSubnet(ctx, sn2, ip.IP6Net{}, attrs, 24*time.Hour); err != nil {
+		t.Fatal("Failed to create second subnet lease", err)
+	}
+	if !waitForEvent(receiver, lease.EventAdded, sn2, 10*time.Second) {
+		t.Fatal("watchSubnets did not resume delivering live events after recovery")
+	}
+}
+
+func waitForSnapshot(receiver chan []lease.LeaseWatchResult, sn ip.IP4Net, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		select {
+		case batch := <-receiver:
+			for _, wr := range batch {
+				for _, l := range wr.Snapshot {
+					if l.Subnet.Equal(sn) {
+						return true
+					}
+				}
+			}
+		case <-deadline:
+			return false
+		}
+	}
+}
+
+func waitForEvent(receiver chan []lease.LeaseWatchResult, etype lease.EventType, sn ip.IP4Net, timeout time.Duration) bool {
+	deadline := time.After(timeout)
+	for {
+		select {
+		case batch := <-receiver:
+			for _, wr := range batch {
+				for _, ev := range wr.Events {
+					if ev.Type == etype && ev.Lease.Subnet.Equal(sn) {
+						return true
+					}
+				}
+			}
+		case <-deadline:
+			return false
+		}
+	}
+}


### PR DESCRIPTION
## Description

This is a bug fix for the etcd subnet manager, whose lease watch never recovers from an etcd compaction: once the watch's start revision has been compacted away, `watchSubnets` reconnects at that same revision indefinitely, hot-looping on `mvcc: required revision has been compacted` and logging a WARN+INFO pair on every reconnect. We hit this in production, where a long-lived node logged ~7.7 GB/day until its disk filled. Full root-cause and a reproduction in #2470.

The watch takes a `since` revision that's never advanced, so once it drifts below the compaction horizon any reconnect wedges. The existing `leasesWatchReset()` recovery was only reachable from the per-event `isIndexTooSmall` path, which a compaction (a watch-response error, not a parse error) never reaches. This detects a compacted watch response and recovers by re-listing at a current revision and resuming, and advances the resume revision as events arrive so an ordinary reconnect moves forward. The per-reconnect "watching subnets starting from rev" log drops to `V(4)`.

The single-subnet `watchSubnet` path has the same hot-loop, but its correct recovery is less clear-cut (single-subnet re-list, and whether the watch should terminate when the lease is gone, which would differ from how it handles a normal delete today). I've left it out of this PR and noted the open question in #2470 rather than guess at the contract.

Testing: `TestWatchSubnetsRecoversFromCompaction` (new) uses the existing `integration` harness to compact etcd past the watch's start revision and assert recovery. Verified it fails on master (hangs) and passes with the fix. Full `pkg/subnet/etcd` suite passes; gofmt, `go vet`, golangci-lint clean.

Components: `pkg/subnet/etcd`. Affects all backends on the etcd datastore; the kube subnet manager is unaffected.

## Todos
- [x] Tests
- [ ] Documentation (n/a)
- [x] Release note

## Release Note
```release-note
Fix the etcd subnet manager hot-looping forever after an etcd compaction, which could flood logs and fill a node's disk. The watch now re-lists at a current revision and resumes instead of reconnecting at the compacted revision.
```
