### PR TITLE
etcd: bug fixes suggested by Claude

### DIFF
--- a/pkg/subnet/etcd/registry.go
+++ b/pkg/subnet/etcd/registry.go
@@ -331,10 +331,17 @@ func (esr *etcdSubnetRegistry) watchSubnets(ctx context.Context, leaseWatchChan 
 								break innerLoop
 							}
 							log.Errorf("failed to re-list subnets after compaction: %v", rerr)
+							timer := time.NewTimer(exponentialBackoff)
 							select {
 							case <-ctx.Done():
-								break innerLoop
-							case <-time.After(exponentialBackoff):
+								timer.Stop()
+								err := esr.cli.Close()
+								if err != nil {
+									log.Errorf("Failed to close etcd client: %v", err)
+								}
+								close(leaseWatchChan)
+								return ctx.Err()
+							case <-timer.C:
 							}
 							exponentialBackoff = min(exponentialBackoff*2, maxBackoff)
 						}

--- a/pkg/subnet/etcd/registry.go
+++ b/pkg/subnet/etcd/registry.go
@@ -322,17 +322,22 @@ func (esr *etcdSubnetRegistry) watchSubnets(ctx context.Context, leaseWatchChan 
 					// revision has been compacted). Re-list to grab a fresh snapshot at
 					// a current revision and resume from there instead of hot-looping.
 					if isCompacted(wresp) {
-						log.Warningf("etcd watch for %s fell behind compaction, re-listing and resuming", key)
-						next, rerr := esr.resyncWatch(ctx, leaseWatchChan)
-						if rerr != nil {
+						log.Warningf("etcd watch for %s fell behind compaction horizon (compact rev %d), re-listing and resuming", key, wresp.CompactRevision)
+						for {
+							next, rerr := esr.resyncWatch(ctx, leaseWatchChan)
+							if rerr == nil {
+								since = next
+								exponentialBackoff = initialBackoff
+								break innerLoop
+							}
 							log.Errorf("failed to re-list subnets after compaction: %v", rerr)
-							time.Sleep(exponentialBackoff)
+							select {
+							case <-ctx.Done():
+								break innerLoop
+							case <-time.After(exponentialBackoff):
+							}
 							exponentialBackoff = min(exponentialBackoff*2, maxBackoff)
-							break innerLoop
 						}
-						since = next
-						exponentialBackoff = initialBackoff
-						break innerLoop
 					}
 					log.Warningf("etcd watch channel for %s closed (%v), reconnecting from rev %d...", key, err, since)
 					time.Sleep(exponentialBackoff)
@@ -561,7 +566,11 @@ func (esr *etcdSubnetRegistry) resyncWatch(ctx context.Context, ch chan []lease.
 	if err != nil {
 		return 0, err
 	}
-	ch <- []lease.LeaseWatchResult{wr}
+	select {
+	case ch <- []lease.LeaseWatchResult{wr}:
+	case <-ctx.Done():
+		return 0, ctx.Err()
+	}
 	return getNextIndex(wr.Cursor)
 }
 

--- a/pkg/subnet/etcd/registry_test.go
+++ b/pkg/subnet/etcd/registry_test.go
@@ -282,6 +282,59 @@ func TestWatchSubnetsRecoversFromCompaction(t *testing.T) {
 	}
 }
 
+// TestResyncWatchCancelWithBlockedReceiver is a regression test for the
+// ctx-aware send in resyncWatch. Before the fix, a blocked receiver caused
+// resyncWatch to hang indefinitely. After the fix it must return
+// context.Canceled promptly.
+func TestResyncWatchCancelWithBlockedReceiver(t *testing.T) {
+	integration.BeforeTestExternal(t)
+
+	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
+	defer clus.Terminate(t)
+
+	client := clus.RandClient()
+	ctx := context.Background()
+	r, kvApi := newTestEtcdRegistry(t, ctx, client)
+
+	if _, err := kvApi.Put(ctx, "/coreos.com/network/config",
+		`{ "Network": "10.1.0.0/16", "Backend": { "Type": "host-gw" } }`); err != nil {
+		t.Fatal("seed config:", err)
+	}
+
+	sn := ip.IP4Net{IP: ip.MustParseIP4("10.1.5.0"), PrefixLen: 24}
+	attrs := &lease.LeaseAttrs{PublicIP: ip.MustParseIP4("1.2.3.4")}
+	if _, err := r.createSubnet(ctx, sn, ip.IP6Net{}, attrs, 24*time.Hour); err != nil {
+		t.Fatal("seed subnet:", err)
+	}
+
+	// Unbuffered receiver: resyncWatch's send blocks until a reader arrives
+	// or the context is canceled.
+	receiver := make(chan []lease.LeaseWatchResult)
+	watchCtx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() {
+		esr := r.(*etcdSubnetRegistry)
+		_, err := esr.resyncWatch(watchCtx, receiver)
+		done <- err
+	}()
+
+	// 500 ms is generous for a re-list over loopback; by then the goroutine
+	// should be blocked in the select waiting to send to the unbuffered receiver.
+	time.Sleep(500 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != context.Canceled {
+			t.Fatalf("resyncWatch returned %v, want context.Canceled", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("resyncWatch did not exit within 3s after context cancellation with blocked receiver")
+	}
+}
+
 func waitForSnapshot(receiver chan []lease.LeaseWatchResult, sn ip.IP4Net, timeout time.Duration) bool {
 	deadline := time.After(timeout)
 	for {


### PR DESCRIPTION
registry.go:569-573 — resyncWatch send wrapped in select { case ch <-: case <-ctx.Done(): return 0, ctx.Err() }. Goroutine can now exit when context cancelled under backpressure.

registry.go:326-340 — Failed resyncWatch now retries directly in a loop (with backoff + ctx escape) instead of breaking to the outer loop and doing a doomed Watch(compactedSince) that immediately fails again.

registry.go:325 — Log message now includes wresp.CompactRevision so operators can see how far behind the watch fell.

## Description
<!-- A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR
-->

## Todos
- [ ] Tests
- [ ] Documentation
- [ ] Release note

## Release Note
<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
None required
```
