### PR TITLE
Pin Dockerfile base images to SHA digests

### DIFF
--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,6 +1,6 @@
-ARG XX_IMAGE=tonistiigi/xx:1.8.0
-ARG GO_IMAGE=golang:alpine3.24
-ARG RUN_IMAGE=alpine:3.24
+ARG XX_IMAGE=tonistiigi/xx:1.8.0@sha256:add602d55daca18914838a78221f6bbe4284114b452c86a48f96d59aeb00f5c6
+ARG GO_IMAGE=golang:alpine3.24@sha256:0178a641fbb4858c5f1b48e34bdaabe0350a330a1b1149aabd498d0699ff5fb2
+ARG RUN_IMAGE=alpine:3.24@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
 
 FROM --platform=$BUILDPLATFORM ${XX_IMAGE}  AS xx
 

--- a/images/iperf3/Dockerfile
+++ b/images/iperf3/Dockerfile
@@ -1,4 +1,6 @@
-FROM BASEIMAGE
+ARG BASEIMAGE=amd64/alpine:3.24@sha256:a0a65670a97d4d6ffc87eed1175c9c7d699813489e0913d96c7b917d7b51e456
+
+FROM ${BASEIMAGE}
 
 RUN apk add --update \
     iperf3 \

--- a/images/iperf3/Makefile
+++ b/images/iperf3/Makefile
@@ -2,16 +2,14 @@ IPERF_IMG ?= iperf3:latest
 
 ARCH ?= amd64
 
-TEMP_DIR := $(shell mktemp -d)
-
 ifeq ($(ARCH),amd64)
-        BASEIMAGE=amd64/alpine:3.24
+        BASEIMAGE=amd64/alpine:3.24@sha256:a0a65670a97d4d6ffc87eed1175c9c7d699813489e0913d96c7b917d7b51e456
 endif
 ifeq ($(ARCH),arm64)
-	BASEIMAGE=arm64v8/alpine:3.24
+	BASEIMAGE=arm64v8/alpine:3.24@sha256:65b6d5e8cc3010146b8b28cad29473b67883635fbedc9851f05ac83fb713ebdb
 endif
 ifeq ($(ARCH),ppc64le)
-	BASEIMAGE=ppc64le/alpine:3.24
+	BASEIMAGE=ppc64le/alpine:3.24@sha256:2b2dcda826915dfbd61de6b3b09d7dd6eb4252800b90c2ffa8ae9b040f6f4806
 endif
 
 .PHONY: all container
@@ -19,10 +17,6 @@ endif
 all: container
 
 container:
-	@echo "Copying files to $(TEMP_DIR)..."
-	@cp ./* $(TEMP_DIR) || { echo "ERROR: Failed to copy files"; exit 1; }
-	@echo "Preparing Dockerfile..."
-	@cd $(TEMP_DIR) && sed -i 's|BASEIMAGE|$(BASEIMAGE)|g' Dockerfile || { echo "ERROR: Failed to prepare Dockerfile"; exit 1; }
 	@echo "Building iperf3 container image..."
-	@docker build --pull -t $(IPERF_IMG) -f $(TEMP_DIR)/Dockerfile $(TEMP_DIR) || { echo "ERROR: Docker build failed for iperf3"; exit 1; }
+	@docker build --pull -t $(IPERF_IMG) --build-arg BASEIMAGE=$(BASEIMAGE) -f Dockerfile . || { echo "ERROR: Docker build failed for iperf3"; exit 1; }
 	@echo "Successfully built iperf3 image: $(IPERF_IMG)"


### PR DESCRIPTION
## Summary

Resolves Scorecard `PinnedDependencies` code scanning alerts by pinning all base images to their SHA256 digests.

## Changes

### `images/Dockerfile`
Pinned ARG defaults for all three base images:
- `tonistiigi/xx:1.8.0` → `@sha256:add602d55...`
- `golang:alpine3.24` → `@sha256:0178a641...`
- `alpine:3.24` → `@sha256:28bd5fe8...`

### `images/iperf3/Dockerfile`
- Converted from literal `FROM BASEIMAGE` (sed template pattern) to `ARG BASEIMAGE=...` + `FROM ${BASEIMAGE}` with pinned default digest

### `images/iperf3/Makefile`
- Pinned each arch-specific BASEIMAGE value with its SHA256 digest
- Replaced the `sed`-based temp-directory substitution with `--build-arg BASEIMAGE=$(BASEIMAGE)` passed directly to `docker build` — simpler and no temp directory needed