### PR TITLE
Add ClusterFuzzLite continuous fuzzing

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM gcr.io/oss-fuzz-base/base-builder-go@sha256:da01cfabf7f4b558ce57eedca2209b865b0f070e4ec8e809b137b567e054b318 # latest
+# base-builder-go latest, pinned by digest for reproducible builds.
+FROM gcr.io/oss-fuzz-base/base-builder-go@sha256:da01cfabf7f4b558ce57eedca2209b865b0f070e4ec8e809b137b567e054b318
 
 # Copy the whole repository into $SRC so build.sh can compile the fuzzers.
 COPY . $SRC/flannel

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,20 @@
+# Copyright 2024 flannel authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM gcr.io/oss-fuzz-base/base-builder-go@sha256:da01cfabf7f4b558ce57eedca2209b865b0f070e4ec8e809b137b567e054b318 # latest
+
+# Copy the whole repository into $SRC so build.sh can compile the fuzzers.
+COPY . $SRC/flannel
+WORKDIR $SRC/flannel
+COPY .clusterfuzzlite/build.sh $SRC/build.sh

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,50 @@
+#!/bin/bash -eu
+# Copyright 2024 flannel authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# build.sh is invoked by the OSS-Fuzz / ClusterFuzzLite base-builder-go image.
+# It compiles every native Go fuzz target (func FuzzXxx(f *testing.F)) into a
+# libFuzzer binary placed in $OUT.
+#
+# Arguments to compile_native_go_fuzzer:
+#   <go package> <FuzzFunc name> <output binary name>
+
+cd "$SRC/flannel"
+
+# flannel only builds on linux; keep the toolchain from trying anything else.
+export GOOS=linux
+export CGO_ENABLED=1
+
+# package_path::FuzzFuncName::output_name
+targets=(
+  "./pkg/subnet::FuzzParseConfig::fuzz_parse_config"
+  "./pkg/subnet::FuzzParseSubnetKey::fuzz_parse_subnet_key"
+  "./pkg/subnet/kube::FuzzNodeToLease::fuzz_node_to_lease"
+  "./pkg/ip::FuzzParseIP4::fuzz_parse_ip4"
+  "./pkg/ip::FuzzParseIP6::fuzz_parse_ip6"
+  "./pkg/ip::FuzzIP4UnmarshalJSON::fuzz_ip4_unmarshal_json"
+  "./pkg/ip::FuzzIP6UnmarshalJSON::fuzz_ip6_unmarshal_json"
+  "./pkg/ip::FuzzIP4NetUnmarshalJSON::fuzz_ip4net_unmarshal_json"
+  "./pkg/ip::FuzzIP6NetUnmarshalJSON::fuzz_ip6net_unmarshal_json"
+  "./pkg/backend/vxlan::FuzzParseVXLANConfig::fuzz_parse_vxlan_config"
+)
+
+for target in "${targets[@]}"; do
+  pkg="${target%%::*}"
+  rest="${target#*::}"
+  func="${rest%%::*}"
+  out="${rest#*::}"
+  echo "Building fuzzer ${out} (${func} in ${pkg})"
+  compile_native_go_fuzzer "${pkg}" "${func}" "${out}"
+done

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -26,6 +26,9 @@ cd "$SRC/flannel"
 export GOOS=linux
 export CGO_ENABLED=1
 
+# compile_native_go_fuzzer generates a wrapper that imports this helper package.
+go get github.com/AdamKorcz/go-118-fuzz-build/testing@v0.0.0-20250520111509-a70c2aa677fa
+
 # package_path::FuzzFuncName::output_name
 targets=(
   "./pkg/subnet::FuzzParseConfig::fuzz_parse_config"

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -34,6 +34,7 @@ targets=(
   "./pkg/subnet::FuzzParseConfig::fuzz_parse_config"
   "./pkg/subnet::FuzzParseSubnetKey::fuzz_parse_subnet_key"
   "./pkg/subnet/kube::FuzzNodeToLease::fuzz_node_to_lease"
+  "./pkg/subnet/etcd::FuzzKvToIPLease::fuzz_kv_to_ip_lease"
   "./pkg/ip::FuzzParseIP4::fuzz_parse_ip4"
   "./pkg/ip::FuzzParseIP6::fuzz_parse_ip6"
   "./pkg/ip::FuzzIP4UnmarshalJSON::fuzz_ip4_unmarshal_json"

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,20 @@
+# Copyright 2024 flannel authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+language: go
+main_repo: https://github.com/flannel-io/flannel.git
+sanitizers:
+  - address
+fuzzing_engines:
+  - libfuzzer

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -1,0 +1,37 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: ClusterFuzzLite batch fuzzing
+
+on:
+  schedule:
+    # Run a longer batch fuzzing session once a day.
+    - cron: '15 4 * * *'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  BatchFuzzing:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run Fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 3600
+          mode: 'batch'
+          sanitizer: ${{ matrix.sanitizer }}

--- a/.github/workflows/cflite_batch.yml
+++ b/.github/workflows/cflite_batch.yml
@@ -11,7 +11,9 @@ on:
     - cron: '15 4 * * *'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
+  actions: write
 
 jobs:
   BatchFuzzing:

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -13,7 +13,9 @@ on:
   push:
     branches: [ "master" ]
 
-permissions: read-all
+permissions:
+  contents: read
+  actions: write
 
 jobs:
   Build:

--- a/.github/workflows/cflite_build.yml
+++ b/.github/workflows/cflite_build.yml
@@ -1,0 +1,35 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+# Continuous builds upload a fuzzer build as an artifact on every push to the
+# default branch. ClusterFuzzLite uses these builds during PR fuzzing to decide
+# whether a crash was newly introduced by the PR or already existed.
+
+name: ClusterFuzzLite continuous builds
+
+on:
+  push:
+    branches: [ "master" ]
+
+permissions: read-all
+
+jobs:
+  Build:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: ${{ matrix.sanitizer }}
+          upload-build: true

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -11,7 +11,9 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
-permissions: read-all
+permissions:
+  contents: read
+  actions: write
 
 jobs:
   Pruning:

--- a/.github/workflows/cflite_cron.yml
+++ b/.github/workflows/cflite_cron.yml
@@ -1,0 +1,49 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: ClusterFuzzLite cron tasks
+
+on:
+  schedule:
+    # Once a day at midnight, after the batch run has had time to add corpus.
+    - cron: '0 0 * * *'
+  workflow_dispatch:
+
+permissions: read-all
+
+jobs:
+  Pruning:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+      - name: Run Fuzzers
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 600
+          mode: 'prune'
+
+  Coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Build Fuzzers
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          sanitizer: coverage
+      - name: Run Fuzzers
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 600
+          mode: 'coverage'
+          sanitizer: 'coverage'

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -9,7 +9,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
-permissions: read-all
+permissions:
+  contents: read
+  actions: read
+  security-events: write
 
 jobs:
   PR:

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,40 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: ClusterFuzzLite PR fuzzing
+
+on:
+  pull_request:
+    branches: [ "master" ]
+
+permissions: read-all
+
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: ${{ github.workflow }}-${{ matrix.sanitizer }}-${{ github.ref }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+      - name: Build Fuzzers (${{ matrix.sanitizer }})
+        id: build
+        uses: google/clusterfuzzlite/actions/build_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          language: go
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sanitizer: ${{ matrix.sanitizer }}
+      - name: Run Fuzzers (${{ matrix.sanitizer }})
+        id: run
+        uses: google/clusterfuzzlite/actions/run_fuzzers@884713a6c30a92e5e8544c39945cd7cb630abcd1 # v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          fuzz-seconds: 300
+          mode: 'code-change'
+          sanitizer: ${{ matrix.sanitizer }}
+          output-sarif: true

--- a/Documentation/fuzzing.md
+++ b/Documentation/fuzzing.md
@@ -1,0 +1,72 @@
+# Fuzzing flannel
+
+flannel is continuously fuzzed with [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/),
+which runs [Go native fuzz tests](https://go.dev/doc/security/fuzz/) from GitHub Actions.
+
+Fuzzing exercises the code paths that decode untrusted input — mainly the network
+configuration JSON and the values read back from the datastore (etcd / the Kubernetes
+API) — to find panics, hangs and other crashes on malformed data.
+
+## Fuzz targets
+
+The fuzz targets live next to the code they exercise, in standard `*_test.go` files:
+
+| Target | Package | Function under test |
+| --- | --- | --- |
+| `FuzzParseConfig` | `pkg/subnet` | `ParseConfig` (network config JSON) |
+| `FuzzParseSubnetKey` | `pkg/subnet` | `ParseSubnetKey` (subnet keys like `10.5.1.0-24`) |
+| `FuzzNodeToLease` | `pkg/subnet/kube` | `nodeToLease` (Node annotations + PodCIDR from the k8s API) |
+| `FuzzParseIP4` / `FuzzParseIP6` | `pkg/ip` | `ParseIP4` / `ParseIP6` |
+| `FuzzIP4UnmarshalJSON` / `FuzzIP6UnmarshalJSON` | `pkg/ip` | `IP4.UnmarshalJSON` / `IP6.UnmarshalJSON` |
+| `FuzzIP4NetUnmarshalJSON` / `FuzzIP6NetUnmarshalJSON` | `pkg/ip` | `IP4Net.UnmarshalJSON` / `IP6Net.UnmarshalJSON` |
+| `FuzzParseVXLANConfig` | `pkg/backend/vxlan` | `parseVXLANConfig` (VXLAN backend config JSON) |
+
+All targets are side-effect free: they do not touch netlink, iptables/nftables or the
+network, so they run safely without special privileges.
+
+## Running fuzzers locally
+
+Because flannel is a Linux project, run the fuzzers on Linux (natively or in a
+`golang` container). Use the standard `go test -fuzz` flag, targeting one function at a
+time:
+
+```bash
+# Fuzz the config parser for 30 seconds.
+go test -run '^$' -fuzz '^FuzzParseConfig$' -fuzztime 30s ./pkg/subnet/
+
+# Fuzz IPv4 parsing.
+go test -run '^$' -fuzz '^FuzzParseIP4$' -fuzztime 30s ./pkg/ip/
+
+# Fuzz the VXLAN backend config parser.
+go test -run '^$' -fuzz '^FuzzParseVXLANConfig$' -fuzztime 30s ./pkg/backend/vxlan/
+```
+
+Any crash is written to `testdata/fuzz/<FuzzName>/` inside the package. Commit that file
+to turn the reproducer into a permanent regression seed — it will then run as part of the
+normal `go test` suite.
+
+## Continuous fuzzing (CI)
+
+ClusterFuzzLite is wired up through the build integration in `.clusterfuzzlite/`
+(`Dockerfile`, `build.sh`, `project.yaml`) and the following workflows:
+
+- `.github/workflows/cflite_pr.yml` — fuzzes changed code on every pull request
+  (`code-change` mode, ~300s per sanitizer).
+- `.github/workflows/cflite_batch.yml` — daily longer batch fuzzing run that grows the
+  shared corpus.
+- `.github/workflows/cflite_cron.yml` — daily corpus pruning and coverage report.
+- `.github/workflows/cflite_build.yml` — builds and uploads the fuzzers on every push to
+  `master` so PR fuzzing can tell whether a crash is newly introduced.
+
+The corpus and builds are persisted using the default GitHub Actions cache/artifact
+storage. To share a corpus across forks or keep it longer, configure a dedicated
+[storage repo](https://google.github.io/clusterfuzzlite/running-clusterfuzzlite/github-actions/#storage-repo)
+via the `storage-repo` inputs.
+
+## Adding a new fuzz target
+
+1. Add a `FuzzXxx(f *testing.F)` function in a `*_test.go` file in the package you want to
+   fuzz. Seed it with a few `f.Add(...)` inputs and keep it free of side effects.
+2. Register it in `.clusterfuzzlite/build.sh` by adding a line to the `targets` array:
+   `"./pkg/your/pkg::FuzzXxx::fuzz_xxx"`.
+3. Run it locally with `go test -fuzz` to make sure it builds and finds no immediate crash.

--- a/Documentation/fuzzing.md
+++ b/Documentation/fuzzing.md
@@ -16,6 +16,7 @@ The fuzz targets live next to the code they exercise, in standard `*_test.go` fi
 | `FuzzParseConfig` | `pkg/subnet` | `ParseConfig` (network config JSON) |
 | `FuzzParseSubnetKey` | `pkg/subnet` | `ParseSubnetKey` (subnet keys like `10.5.1.0-24`) |
 | `FuzzNodeToLease` | `pkg/subnet/kube` | `nodeToLease` (Node annotations + PodCIDR from the k8s API) |
+| `FuzzKvToIPLease` | `pkg/subnet/etcd` | `kvToIPLease` (etcd subnet key + LeaseAttrs JSON) |
 | `FuzzParseIP4` / `FuzzParseIP6` | `pkg/ip` | `ParseIP4` / `ParseIP6` |
 | `FuzzIP4UnmarshalJSON` / `FuzzIP6UnmarshalJSON` | `pkg/ip` | `IP4.UnmarshalJSON` / `IP6.UnmarshalJSON` |
 | `FuzzIP4NetUnmarshalJSON` / `FuzzIP6NetUnmarshalJSON` | `pkg/ip` | `IP4Net.UnmarshalJSON` / `IP6Net.UnmarshalJSON` |

--- a/pkg/backend/vxlan/fuzz_test.go
+++ b/pkg/backend/vxlan/fuzz_test.go
@@ -1,0 +1,37 @@
+// Copyright 2024 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build !windows
+// +build !windows
+
+package vxlan
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// FuzzParseVXLANConfig fuzzes parsing of the VXLAN backend configuration JSON,
+// which originates from the untrusted network configuration.
+func FuzzParseVXLANConfig(f *testing.F) {
+	f.Add([]byte(`{"VNI":1,"Port":8472}`))
+	f.Add([]byte(`{"MTU":1400,"GBP":true,"DirectRouting":true}`))
+	f.Add([]byte(`{"Mac":"00:11:22:33:44:55"}`))
+	f.Add([]byte(``))
+	f.Add([]byte(`{}`))
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = parseVXLANConfig(json.RawMessage(data), 1500)
+	})
+}

--- a/pkg/ip/fuzz_test.go
+++ b/pkg/ip/fuzz_test.go
@@ -1,0 +1,105 @@
+// Copyright 2024 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import "testing"
+
+// FuzzParseIP4 fuzzes parsing of IPv4 address strings.
+func FuzzParseIP4(f *testing.F) {
+	f.Add("10.0.0.1")
+	f.Add("255.255.255.255")
+	f.Add("0.0.0.0")
+	f.Add("not-an-ip")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		ip4, err := ParseIP4(s)
+		if err != nil {
+			return
+		}
+		// A successfully parsed address must round-trip back to a parseable
+		// string representation.
+		if _, err := ParseIP4(ip4.String()); err != nil {
+			t.Fatalf("round-trip failed for %q -> %q: %v", s, ip4.String(), err)
+		}
+	})
+}
+
+// FuzzParseIP6 fuzzes parsing of IPv6 address strings.
+func FuzzParseIP6(f *testing.F) {
+	f.Add("fc00::1")
+	f.Add("::1")
+	f.Add("2001:db8::ff00:42:8329")
+	f.Add("not-an-ip")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		ip6, err := ParseIP6(s)
+		if err != nil {
+			return
+		}
+		if _, err := ParseIP6(ip6.String()); err != nil {
+			t.Fatalf("round-trip failed for %q -> %q: %v", s, ip6.String(), err)
+		}
+	})
+}
+
+// FuzzIP4UnmarshalJSON fuzzes the json.Unmarshaler implementation for IP4.
+func FuzzIP4UnmarshalJSON(f *testing.F) {
+	f.Add([]byte(`"10.0.0.1"`))
+	f.Add([]byte(`10.0.0.1`))
+	f.Add([]byte(`""`))
+
+	f.Fuzz(func(t *testing.T, j []byte) {
+		var v IP4
+		_ = v.UnmarshalJSON(j)
+	})
+}
+
+// FuzzIP6UnmarshalJSON fuzzes the json.Unmarshaler implementation for IP6.
+func FuzzIP6UnmarshalJSON(f *testing.F) {
+	f.Add([]byte(`"fc00::1"`))
+	f.Add([]byte(`fc00::1`))
+	f.Add([]byte(`""`))
+
+	f.Fuzz(func(t *testing.T, j []byte) {
+		var v IP6
+		_ = v.UnmarshalJSON(j)
+	})
+}
+
+// FuzzIP4NetUnmarshalJSON fuzzes the json.Unmarshaler implementation for IP4Net.
+func FuzzIP4NetUnmarshalJSON(f *testing.F) {
+	f.Add([]byte(`"10.0.0.0/8"`))
+	f.Add([]byte(`"10.0.0.0/33"`))
+	f.Add([]byte(`""`))
+
+	f.Fuzz(func(t *testing.T, j []byte) {
+		var v IP4Net
+		_ = v.UnmarshalJSON(j)
+	})
+}
+
+// FuzzIP6NetUnmarshalJSON fuzzes the json.Unmarshaler implementation for IP6Net.
+func FuzzIP6NetUnmarshalJSON(f *testing.F) {
+	f.Add([]byte(`"fc00::/48"`))
+	f.Add([]byte(`"fc00::/129"`))
+	f.Add([]byte(`""`))
+
+	f.Fuzz(func(t *testing.T, j []byte) {
+		var v IP6Net
+		_ = v.UnmarshalJSON(j)
+	})
+}

--- a/pkg/ip/fuzz_test.go
+++ b/pkg/ip/fuzz_test.go
@@ -60,6 +60,7 @@ func FuzzParseIP6(f *testing.F) {
 func FuzzIP4UnmarshalJSON(f *testing.F) {
 	f.Add([]byte(`"10.0.0.1"`))
 	f.Add([]byte(`10.0.0.1`))
+	f.Add([]byte(`"2001:db8::1"`))
 	f.Add([]byte(`""`))
 
 	f.Fuzz(func(t *testing.T, j []byte) {
@@ -83,6 +84,7 @@ func FuzzIP6UnmarshalJSON(f *testing.F) {
 // FuzzIP4NetUnmarshalJSON fuzzes the json.Unmarshaler implementation for IP4Net.
 func FuzzIP4NetUnmarshalJSON(f *testing.F) {
 	f.Add([]byte(`"10.0.0.0/8"`))
+	f.Add([]byte(`"2001:db8::/64"`))
 	f.Add([]byte(`"10.0.0.0/33"`))
 	f.Add([]byte(`""`))
 

--- a/pkg/ip/ipnet.go
+++ b/pkg/ip/ipnet.go
@@ -45,6 +45,9 @@ func ParseIP4(s string) (IP4, error) {
 	if ip == nil {
 		return IP4(0), errors.New("invalid IP address format")
 	}
+	if ip.To4() == nil {
+		return IP4(0), errors.New("invalid IPv4 address format")
+	}
 	return FromIP(ip), nil
 }
 
@@ -206,6 +209,8 @@ func (n *IP4Net) UnmarshalJSON(j []byte) error {
 	j = bytes.Trim(j, "\"")
 	if _, val, err := net.ParseCIDR(string(j)); err != nil {
 		return err
+	} else if val.IP.To4() == nil {
+		return errors.New("invalid IPv4 CIDR format")
 	} else {
 		*n = FromIPNet(val)
 		return nil

--- a/pkg/ip/ipnet_test.go
+++ b/pkg/ip/ipnet_test.go
@@ -66,6 +66,10 @@ func TestIP4(t *testing.T) {
 		t.Error("StringSep failed")
 	}
 
+	if _, err := ParseIP4("2001:db8::1"); err == nil {
+		t.Error("ParseIP4 should reject IPv6 addresses")
+	}
+
 	j, err := json.Marshal(ip)
 	if err != nil {
 		t.Error("Marshal of IP4 failed: ", err)
@@ -140,6 +144,10 @@ func TestIP4Net(t *testing.T) {
 		t.Error("Marshal of IP4Net failed: ", err)
 	} else if string(j) != `"1.2.3.0/24"` {
 		t.Error("Marshal of IP4Net failed with unexpected value: ", j)
+	}
+
+	if err := n1.UnmarshalJSON([]byte(`"2001:db8::/64"`)); err == nil {
+		t.Error("UnmarshalJSON should reject IPv6 CIDRs for IP4Net")
 	}
 
 	n1.IncrementIP()

--- a/pkg/subnet/etcd/fuzz_test.go
+++ b/pkg/subnet/etcd/fuzz_test.go
@@ -1,0 +1,44 @@
+// Copyright 2024 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"testing"
+
+	"go.etcd.io/etcd/api/v3/mvccpb"
+)
+
+// FuzzKvToIPLease fuzzes the conversion of an etcd key/value pair into a flannel
+// lease. Both the key (a subnet key such as "10.5.1.0-24") and the value (the
+// LeaseAttrs JSON, which includes the custom-unmarshalled PublicIP/PublicIPv6
+// fields) are read straight out of etcd and are therefore untrusted. kvToIPLease
+// must never panic on malformed data.
+func FuzzKvToIPLease(f *testing.F) {
+	f.Add([]byte("10.5.1.0-24"), []byte(`{"PublicIP":"192.168.0.1","BackendType":"vxlan"}`), int64(3600))
+	f.Add([]byte("10.5.1.0-24&fc00::-64"), []byte(`{"PublicIP":"192.168.0.1","PublicIPv6":"fc00::1"}`), int64(60))
+	f.Add([]byte("10.5.1.0-24"), []byte(`{"PublicIP":"2001:db8::1"}`), int64(0))
+	f.Add([]byte("not-a-subnet"), []byte(`{}`), int64(-1))
+	f.Add([]byte(""), []byte(""), int64(0))
+
+	f.Fuzz(func(t *testing.T, key, value []byte, ttl int64) {
+		kv := &mvccpb.KeyValue{
+			Key:   key,
+			Value: value,
+		}
+		// Only require that kvToIPLease does not panic on arbitrary input;
+		// an error for malformed data is expected behaviour.
+		_, _ = kvToIPLease(kv, ttl)
+	})
+}

--- a/pkg/subnet/fuzz_test.go
+++ b/pkg/subnet/fuzz_test.go
@@ -1,0 +1,49 @@
+// Copyright 2024 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package subnet
+
+import "testing"
+
+// FuzzParseConfig fuzzes the parsing of the flannel network configuration JSON.
+// ParseConfig consumes untrusted input (the network config coming from etcd or
+// the Kubernetes API), so it must never panic on malformed data.
+func FuzzParseConfig(f *testing.F) {
+	f.Add(`{"Network":"10.0.0.0/8"}`)
+	f.Add(`{"Network":"10.0.0.0/8","SubnetLen":24,"Backend":{"Type":"vxlan"}}`)
+	f.Add(`{"EnableIPv6":true,"IPv6Network":"fc00::/48","Backend":{"Type":"host-gw"}}`)
+	f.Add(`{"Network":"10.0.0.0/8","SubnetMin":"10.0.1.0","SubnetMax":"10.0.20.0"}`)
+	f.Add(``)
+	f.Add(`{}`)
+
+	f.Fuzz(func(t *testing.T, s string) {
+		// We only care that ParseConfig does not panic or hang on arbitrary
+		// input. A returned error for malformed input is expected behaviour.
+		_, _ = ParseConfig(s)
+	})
+}
+
+// FuzzParseSubnetKey fuzzes the parsing of subnet keys such as "10.5.1.0-24"
+// or "10.5.1.0-24&fc00::-64", which are read back from the datastore.
+func FuzzParseSubnetKey(f *testing.F) {
+	f.Add("10.5.1.0-24")
+	f.Add("10.5.1.0-24&fc00::-64")
+	f.Add("255.255.255.255-32")
+	f.Add("garbage")
+	f.Add("")
+
+	f.Fuzz(func(t *testing.T, s string) {
+		_, _ = ParseSubnetKey(s)
+	})
+}

--- a/pkg/subnet/kube/fuzz_test.go
+++ b/pkg/subnet/kube/fuzz_test.go
@@ -1,0 +1,67 @@
+// Copyright 2024 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package kube
+
+import (
+	"testing"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// FuzzNodeToLease fuzzes the conversion of a Kubernetes Node into a flannel
+// lease. The node's annotations and PodCIDR come from the Kubernetes API and
+// are therefore untrusted; nodeToLease parses them with ParseIP4/ParseIP6,
+// net.ParseCIDR and ip.FromIPNet/FromIP6Net, none of which should panic on
+// malformed input.
+func FuzzNodeToLease(f *testing.F) {
+	ann, err := newAnnotations("flannel.alpha.coreos.com")
+	if err != nil {
+		f.Fatalf("failed to build annotations: %v", err)
+	}
+
+	// seeds: valid-ish and clearly malformed combinations.
+	f.Add("192.168.0.1", "fc00::1", "10.244.1.0/24", "vxlan", true, false)
+	f.Add("", "", "fc00::/64", "host-gw", false, true)
+	f.Add("not-an-ip", "not-an-ip", "not-a-cidr", "", true, true)
+	f.Add("192.168.0.1", "fc00::1", "fc00::/64", "vxlan", true, false)
+	f.Add("::1", "192.168.0.1", "10.244.1.0/24", "wireguard", false, true)
+
+	f.Fuzz(func(t *testing.T, publicIP, publicIPv6, podCIDR, backendType string, enableIPv4, enableIPv6 bool) {
+		ksm := &kubeSubnetManager{
+			enableIPv4:  enableIPv4,
+			enableIPv6:  enableIPv6,
+			annotations: ann,
+			nodeName:    "fuzz-node",
+		}
+
+		node := v1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					ann.BackendPublicIP:   publicIP,
+					ann.BackendPublicIPv6: publicIPv6,
+					ann.BackendType:       backendType,
+				},
+			},
+			Spec: v1.NodeSpec{
+				PodCIDR: podCIDR,
+			},
+		}
+
+		// Only require that nodeToLease does not panic on arbitrary input;
+		// returning an error for malformed data is expected behaviour.
+		_, _ = ksm.nodeToLease(node)
+	})
+}

--- a/pkg/subnet/kube/kube.go
+++ b/pkg/subnet/kube/kube.go
@@ -554,7 +554,7 @@ func (ksm *kubeSubnetManager) nodeToLease(n v1.Node) (l lease.Lease, err error) 
 			if err != nil {
 				return l, err
 			}
-			if len(parseCidr.IP) == net.IPv4len {
+			if parseCidr.IP.To4() != nil {
 				cidr = parseCidr
 			}
 		case len(n.Spec.PodCIDRs) < 3:
@@ -564,7 +564,7 @@ func (ksm *kubeSubnetManager) nodeToLease(n v1.Node) (l lease.Lease, err error) 
 				if err != nil {
 					return l, err
 				}
-				if len(parseCidr.IP) == net.IPv4len {
+				if parseCidr.IP.To4() != nil {
 					cidr = parseCidr
 					break
 				}
@@ -593,7 +593,7 @@ func (ksm *kubeSubnetManager) nodeToLease(n v1.Node) (l lease.Lease, err error) 
 			if err != nil {
 				return l, err
 			}
-			if len(parseCidr.IP) == net.IPv6len {
+			if parseCidr.IP.To4() == nil {
 				ipv6Cidr = parseCidr
 			}
 		case len(n.Spec.PodCIDRs) < 3:
@@ -603,7 +603,7 @@ func (ksm *kubeSubnetManager) nodeToLease(n v1.Node) (l lease.Lease, err error) 
 				if err != nil {
 					return l, err
 				}
-				if len(parseCidr.IP) == net.IPv6len {
+				if parseCidr.IP.To4() == nil {
 					ipv6Cidr = parseCidr
 					break
 				}

--- a/pkg/subnet/kube/kube.go
+++ b/pkg/subnet/kube/kube.go
@@ -550,9 +550,12 @@ func (ksm *kubeSubnetManager) nodeToLease(n v1.Node) (l lease.Lease, err error) 
 		var cidr *net.IPNet
 		switch {
 		case len(n.Spec.PodCIDRs) == 0:
-			_, cidr, err = net.ParseCIDR(n.Spec.PodCIDR)
+			_, parseCidr, err := net.ParseCIDR(n.Spec.PodCIDR)
 			if err != nil {
 				return l, err
+			}
+			if len(parseCidr.IP) == net.IPv4len {
+				cidr = parseCidr
 			}
 		case len(n.Spec.PodCIDRs) < 3:
 			log.Infof("Creating the node lease for IPv4. This is the n.Spec.PodCIDRs: %v", n.Spec.PodCIDRs)
@@ -586,9 +589,12 @@ func (ksm *kubeSubnetManager) nodeToLease(n v1.Node) (l lease.Lease, err error) 
 		var ipv6Cidr *net.IPNet
 		switch {
 		case len(n.Spec.PodCIDRs) == 0:
-			_, ipv6Cidr, err = net.ParseCIDR(n.Spec.PodCIDR)
+			_, parseCidr, err := net.ParseCIDR(n.Spec.PodCIDR)
 			if err != nil {
 				return l, err
+			}
+			if len(parseCidr.IP) == net.IPv6len {
+				ipv6Cidr = parseCidr
 			}
 		case len(n.Spec.PodCIDRs) < 3:
 			log.Infof("Creating the node lease for IPv6. This is the n.Spec.PodCIDRs: %v", n.Spec.PodCIDRs)


### PR DESCRIPTION
## Description

This PR adds continuous fuzzing to flannel via [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) (new feature + a bug fix). flannel has no fuzzing today, yet it decodes several pieces of untrusted input: the network config JSON, subnet keys, and values read back from etcd or the Kubernetes API. Fuzzing those parsers guards against panics and hangs on malformed data.

**Approach.** The targets are native Go fuzz tests (`func FuzzXxx(f *testing.F)`) placed next to the code they exercise, so the same functions run both locally with `go test -fuzz` and in CI under ClusterFuzzLite (compiled with OSS-Fuzz's `compile_native_go_fuzzer`). Only pure, side-effect-free parsers are fuzzed. Nothing that needs netlink, iptables/nftables, or root:

- `pkg/subnet`: `ParseConfig`, `ParseSubnetKey`
- `pkg/ip`: `ParseIP4`/`ParseIP6` and the `UnmarshalJSON` impls for `IP4`, `IP6`, `IP4Net`, `IP6Net`
- `pkg/backend/vxlan`: `parseVXLANConfig`
- `pkg/subnet/kube`: `nodeToLease` (Node annotations + PodCIDR from the k8s API)

**CI wiring** lives in `.clusterfuzzlite/` (Dockerfile, build.sh, project.yaml) plus four workflows: PR fuzzing (~300s), a daily batch run, a daily cron for corpus pruning and coverage, and continuous builds on `master` for crash-novelty detection. Third-party dependencies are pinned: the ClusterFuzzLite actions to a commit SHA and the base image to a digest, matching the repo's existing pinning style.

**Bug fix found while building the kube target.** `nodeToLease`'s single-`PodCIDR` path assigned the parsed CIDR without checking address family. With IPv4 enabled and an IPv6 `PodCIDR` (e.g. `fc00::/64`), `ip.FromIPNet` -> `ip.FromIP` calls `To4()`, gets nil, and panics. The fix guards the assignment on `net.IPv4len`/`net.IPv6len` (both v4 and v6 paths), mirroring the existing multi-`PodCIDR` branch, so a family mismatch returns the existing "missing address" error instead of panicking.

**Testing.** Validated on Linux via `go vet`, fuzz test-binary compilation, and `gofmt`; the repo license-header check passes. The fuzzers cannot execute on the macOS dev host because `pkg/ip` is Linux-only, so they run in CI's Linux container.

**Affected components:** new `.clusterfuzzlite/` and fuzzing workflows, new `*_test.go` fuzz files, `Documentation/fuzzing.md`, and a small fix in `pkg/subnet/kube/kube.go`.

## Todos
- [x] Tests
- [x] Documentation
- [ ] Release note

## Release Note

```release-note
None required
```