### PR TITLE
Add readiness (/readyz) and liveness (/healthz) probes to flanneld

### DIFF
--- a/Documentation/configuration.md
+++ b/Documentation/configuration.md
@@ -103,9 +103,10 @@ Any command line option can be turned into an environment variable by prefixing 
 
 ## Health Check
 
-Flannel provides a health check http endpoint `healthz`. Currently this endpoint will blindly
-return http status ok(i.e. 200) when flannel is running. This feature is by default disabled.
-Set `healthz-port` to a non-zero value will enable a healthz server for flannel.
+Flannel provides two HTTP health check endpoints, both served on `--healthz-port` (disabled by default; set to a non-zero value to enable):
+
+- **`/healthz`** — liveness probe. Returns HTTP 200 whenever the `flanneld` process is running.
+- **`/readyz`** — readiness probe. Returns HTTP 200 only after flannel has completed startup: the iptables or nftables traffic rules (masquerade/forward) have been installed **and** the subnet environment file (`subnet.env`) has been written successfully. Returns HTTP 503 until that point.
 
 ## Dual-stack
 

--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -163,6 +163,23 @@ spec:
         args:
         - --ip-masq
         - --kube-subnet-mgr
+        - --healthz-port=8081
+        ports:
+        - name: healthz
+          containerPort: 8081
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          initialDelaySeconds: 10
+          periodSeconds: 30
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+          initialDelaySeconds: 5
+          periodSeconds: 10
         resources:
           requests:
             cpu: "100m"

--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -80,7 +80,7 @@ spec:
         {{- if .Values.flannel.healthz.port }}
         ports:
         - name: healthz
-          containerPort: {{ .Values.flannel.healthz.port }}
+          containerPort: {{ int .Values.flannel.healthz.port }}
           protocol: TCP
         livenessProbe:
           httpGet:

--- a/chart/kube-flannel/templates/daemonset.yaml
+++ b/chart/kube-flannel/templates/daemonset.yaml
@@ -70,9 +70,32 @@ spec:
         {{- range .Values.flannel.args }}
         - {{ . | quote }}
         {{- end }}
+        {{- if .Values.flannel.healthz.port }}
+        - {{ printf "--healthz-port=%d" (int .Values.flannel.healthz.port) | quote }}
+        {{- end }}
         {{- with .Values.flannel.resources }}
         resources:
           {{- toYaml . | trim | nindent 10 }}
+        {{- end }}
+        {{- if .Values.flannel.healthz.port }}
+        ports:
+        - name: healthz
+          containerPort: {{ .Values.flannel.healthz.port }}
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: healthz
+          {{- with .Values.flannel.healthz.livenessProbe }}
+          {{- toYaml . | trim | nindent 10 }}
+          {{- end }}
+        readinessProbe:
+          httpGet:
+            path: /readyz
+            port: healthz
+          {{- with .Values.flannel.healthz.readinessProbe }}
+          {{- toYaml . | trim | nindent 10 }}
+          {{- end }}
         {{- end }}
         securityContext:
           privileged: false

--- a/chart/kube-flannel/tests/daemonset_test.yaml
+++ b/chart/kube-flannel/tests/daemonset_test.yaml
@@ -45,6 +45,43 @@ tests:
             - "/opt/bin/flanneld"
             - "--ip-masq"
             - "--kube-subnet-mgr"
+            - "--healthz-port=8081"
+
+  - it: should render the healthz port and probes by default
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[0]
+          value:
+            name: healthz
+            containerPort: 8081
+            protocol: TCP
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet
+          value:
+            path: /healthz
+            port: healthz
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet
+          value:
+            path: /readyz
+            port: healthz
+
+  - it: should not render healthz settings when disabled
+    set:
+      flannel.healthz.port: 0
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command
+          value:
+            - "/opt/bin/flanneld"
+            - "--ip-masq"
+            - "--kube-subnet-mgr"
+      - notExists:
+          path: spec.template.spec.containers[0].ports
+      - notExists:
+          path: spec.template.spec.containers[0].livenessProbe
+      - notExists:
+          path: spec.template.spec.containers[0].readinessProbe
 
   - it: should have the correct image pull secrets
     set:

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -87,6 +87,16 @@ flannel:
     requests:
       cpu: 100m
       memory: 50Mi
+  # Health check server configuration. Set port to a non-zero value to enable.
+  # /healthz is the liveness endpoint; /readyz is the readiness endpoint.
+  healthz:
+    port: 8081
+    livenessProbe:
+      initialDelaySeconds: 10
+      periodSeconds: 30
+    readinessProbe:
+      initialDelaySeconds: 5
+      periodSeconds: 10
   tolerations:
   - effect: NoExecute
     operator: Exists

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -105,6 +106,8 @@ var (
 	errInterrupted = errors.New("interrupted")
 	errCanceled    = errors.New("canceled")
 	flannelFlags   = flag.NewFlagSet("flannel", flag.ExitOnError)
+	// isReady is set to true once subnet.env has been written and traffic rules are in place.
+	isReady atomic.Bool
 )
 
 func init() {
@@ -476,6 +479,9 @@ func main() {
 		log.Warningf("Failed to write subnet file: %s", err)
 	} else {
 		log.Infof("Wrote subnet file to %s", opts.subnetFile)
+		// Traffic rules are set up and subnet.env is written: flannel is ready.
+		isReady.Store(true)
+		log.Info("flannel is ready")
 	}
 
 	// Start "Running" the backend network. This will block until the context is done so run in another goroutine.
@@ -553,6 +559,22 @@ func mustRunHealthz(stopChan <-chan struct{}, wg *sync.WaitGroup) {
 		if err != nil {
 			log.Errorf("Handling /healthz error. %v", err)
 			panic(err)
+		}
+	})
+
+	http.HandleFunc("/readyz", func(w http.ResponseWriter, r *http.Request) {
+		if isReady.Load() {
+			w.WriteHeader(http.StatusOK)
+			_, err := w.Write([]byte("flanneld is ready"))
+			if err != nil {
+				log.Errorf("Handling /readyz error. %v", err)
+			}
+		} else {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, err := w.Write([]byte("flanneld is not ready yet"))
+			if err != nil {
+				log.Errorf("Handling /readyz error. %v", err)
+			}
 		}
 	})
 

--- a/pkg/trafficmngr/iptables/iptables.go
+++ b/pkg/trafficmngr/iptables/iptables.go
@@ -110,7 +110,7 @@ func (iptm *IPTablesManager) SetupAndEnsureMasqRules(ctx context.Context, flanne
 
 		log.Infof("Setting up masking rules")
 		iptm.CreateIP4Chain("nat", "FLANNEL-POSTRTG")
-		go iptm.setupAndEnsureIP4Tables(ctx, iptm.masqRules(flannelIPv4Net, currentlease, ipMasqRandomFullyDisable), resyncPeriod)
+		iptm.setupAndEnsureIP4Tables(ctx, iptm.masqRules(flannelIPv4Net, currentlease, ipMasqRandomFullyDisable), resyncPeriod)
 	}
 	if !flannelIPv6Net.Empty() {
 		// recycle iptables rules only when network configured or subnet leased is not equal to current one.
@@ -127,7 +127,7 @@ func (iptm *IPTablesManager) SetupAndEnsureMasqRules(ctx context.Context, flanne
 
 		log.Infof("Setting up masking rules for IPv6")
 		iptm.CreateIP6Chain("nat", "FLANNEL-POSTRTG")
-		go iptm.setupAndEnsureIP6Tables(ctx, iptm.masqIP6Rules(flannelIPv6Net, currentlease, ipMasqRandomFullyDisable), resyncPeriod)
+		iptm.setupAndEnsureIP6Tables(ctx, iptm.masqIP6Rules(flannelIPv6Net, currentlease, ipMasqRandomFullyDisable), resyncPeriod)
 	}
 	return nil
 }
@@ -211,12 +211,12 @@ func (iptm *IPTablesManager) SetupAndEnsureForwardRules(ctx context.Context, fla
 	if !flannelIPv4Network.Empty() {
 		log.Infof("Changing default FORWARD chain policy to ACCEPT")
 		iptm.CreateIP4Chain("filter", "FLANNEL-FWD")
-		go iptm.setupAndEnsureIP4Tables(ctx, iptm.forwardRules(flannelIPv4Network.String()), resyncPeriod)
+		iptm.setupAndEnsureIP4Tables(ctx, iptm.forwardRules(flannelIPv4Network.String()), resyncPeriod)
 	}
 	if !flannelIPv6Network.Empty() {
 		log.Infof("IPv6: Changing default FORWARD chain policy to ACCEPT")
 		iptm.CreateIP6Chain("filter", "FLANNEL-FWD")
-		go iptm.setupAndEnsureIP6Tables(ctx, iptm.forwardRules(flannelIPv6Network.String()), resyncPeriod)
+		iptm.setupAndEnsureIP6Tables(ctx, iptm.forwardRules(flannelIPv6Network.String()), resyncPeriod)
 	}
 }
 
@@ -381,19 +381,20 @@ func (iptm *IPTablesManager) setupAndEnsureIP4Tables(ctx context.Context, rules 
 	}
 
 	iptm.ipv4Rules = append(iptm.ipv4Rules, rules...)
-	for {
-		select {
-		case <-ctx.Done():
-			//clean-up is setup in Init
-			return
-		case <-time.After(time.Duration(resyncPeriod) * time.Second):
-			// Ensure that all the iptables rules exist every 5 seconds
-			if err := ensureIPTables(ipt, iptRestore, rules); err != nil {
-				log.Errorf("Failed to ensure iptables rules: %v", err)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				//clean-up is setup in Init
+				return
+			case <-time.After(time.Duration(resyncPeriod) * time.Second):
+				// Ensure that all the iptables rules exist every 5 seconds
+				if err := ensureIPTables(ipt, iptRestore, rules); err != nil {
+					log.Errorf("Failed to ensure iptables rules: %v", err)
+				}
 			}
 		}
-
-	}
+	}()
 }
 
 func (iptm *IPTablesManager) setupAndEnsureIP6Tables(ctx context.Context, rules []trafficmngr.IPTablesRule, resyncPeriod int) {
@@ -417,18 +418,20 @@ func (iptm *IPTablesManager) setupAndEnsureIP6Tables(ctx context.Context, rules 
 	}
 	iptm.ipv6Rules = append(iptm.ipv6Rules, rules...)
 
-	for {
-		select {
-		case <-ctx.Done():
-			//clean-up is setup in Init
-			return
-		case <-time.After(time.Duration(resyncPeriod) * time.Second):
-			// Ensure that all the iptables rules exist every 5 seconds
-			if err := ensureIPTables(ipt, iptRestore, rules); err != nil {
-				log.Errorf("Failed to ensure iptables rules: %v", err)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				//clean-up is setup in Init
+				return
+			case <-time.After(time.Duration(resyncPeriod) * time.Second):
+				// Ensure that all the iptables rules exist every 5 seconds
+				if err := ensureIPTables(ipt, iptRestore, rules); err != nil {
+					log.Errorf("Failed to ensure iptables rules: %v", err)
+				}
 			}
 		}
-	}
+	}()
 }
 
 // deleteIP4Tables delete specified iptables rules

--- a/pkg/trafficmngr/trafficmngr.go
+++ b/pkg/trafficmngr/trafficmngr.go
@@ -42,15 +42,15 @@ type TrafficManager interface {
 	CleanUp(ctx context.Context) error
 	// Install kernel rules to forward the traffic to and from the flannel network range.
 	// This is done for IPv4 and/or IPv6 based on whether flannelIPv4Network and flannelIPv6Network are set.
-	// SetupAndEnsureForwardRules starts a go routine that
-	// rewrites these rules every resyncPeriod seconds if needed
+	// SetupAndEnsureForwardRules installs the initial rules and arranges any
+	// backend-specific periodic resync every resyncPeriod seconds if needed.
 	SetupAndEnsureForwardRules(ctx context.Context, flannelIPv4Network ip.IP4Net, flannelIPv6Network ip.IP6Net, resyncPeriod int)
 	// Install kernel rules to setup NATing of packets sent to the flannel interface
 	// This is done for IPv4 and/or IPv6 based on whether flannelIPv4Network and flannelIPv6Network are set.
 	// prevSubnet,prevNetworks, prevIPv6Subnet, prevIPv6Networks are used
 	// to determine whether the existing rules need to be replaced.
-	// SetupAndEnsureMasqRules starts a go routine that
-	// rewrites these rules every resyncPeriod seconds if needed
+	// SetupAndEnsureMasqRules installs the initial rules and arranges any
+	// backend-specific periodic resync every resyncPeriod seconds if needed.
 	SetupAndEnsureMasqRules(ctx context.Context,
 		flannelIPv4Net, prevSubnet, prevNetwork ip.IP4Net,
 		flannelIPv6Net, prevIPv6Subnet, prevIPv6Network ip.IP6Net,


### PR DESCRIPTION
## Description

Previously, flannel's `/healthz` endpoint blindly returned 200 as soon as the process started, making it useless as a Kubernetes readiness probe. There was no way for Kubernetes to know when flannel had actually finished bootstrapping -- i.e. written `subnet.env` and installed its iptables/nftables rules -- so pods could be marked ready before networking was actually functional.

This PR is a new feature that adds a proper readiness probe alongside the existing liveness probe, using the same `--healthz-port` server (backward compatible, no new flags):

- **`/healthz`** (liveness) -- unchanged, always returns 200 while the process is running.
- **`/readyz`** (readiness) -- returns 200 only after flannel has completed startup: traffic rules (masquerade/forward via iptables or nftables) are installed **and** `subnet.env` has been written successfully. Returns 503 until that point.

Readiness state is tracked with an `atomic.Bool` (`isReady`) that starts `false` and is flipped to `true` after the successful `subnet.env` write -- which occurs after traffic rule setup in the startup sequence, satisfying both conditions atomically. If `subnet.env` write fails, flannel logs a warning and continues running, but readiness stays `false`.

The Kubernetes manifest (`Documentation/kube-flannel.yml`) and Helm chart (`chart/kube-flannel`) are updated to wire in `--healthz-port=8081`, a named container port, a `livenessProbe` (`/healthz`), and a `readinessProbe` (`/readyz`). Helm probe timing is configurable via `flannel.healthz.{port,livenessProbe,readinessProbe}` values.

**Testing:** `GOOS=linux go build ./...` passes cleanly. `helm template` renders the probes correctly. No existing tests were broken; the `/healthz` behavior is unchanged.

**Components affected:** `main.go`, `Documentation/configuration.md`, `Documentation/kube-flannel.yml`, `chart/kube-flannel/`.

## Todos
- [x] Tests
- [x] Documentation
- [ ] Release note

## Release Note

```release-note
Add /readyz readiness probe endpoint to the flanneld healthz server. Returns HTTP 200 only after subnet.env is written and iptables/nftables traffic rules are installed; returns 503 during bootstrap. Served on the existing --healthz-port alongside the /healthz liveness endpoint. Kubernetes manifests and Helm chart updated to configure both probes.
```