### PR TITLE
Bump default CNI config cniVersion to 1.0.0

### DIFF
--- a/Documentation/kube-flannel.yml
+++ b/Documentation/kube-flannel.yml
@@ -71,7 +71,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "flannel",

--- a/Documentation/kustomization/kube-flannel/kube-flannel.yml
+++ b/Documentation/kustomization/kube-flannel/kube-flannel.yml
@@ -63,7 +63,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "flannel",

--- a/Documentation/minikube.yml
+++ b/Documentation/minikube.yml
@@ -20,7 +20,7 @@ data:
   cni-conf.json: |
     {
       "name": "cbr0",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "type": "flannel",
       "delegate": {
         "hairpinMode": true,

--- a/chart/kube-flannel/values.yaml
+++ b/chart/kube-flannel/values.yaml
@@ -63,7 +63,7 @@ flannel:
   cniConf: |
     {
       "name": "cbr0",
-      "cniVersion": "0.3.1",
+      "cniVersion": "1.0.0",
       "plugins": [
         {
           "type": "flannel",


### PR DESCRIPTION
## What

Raise the `cniVersion` declared in the default CNI configuration from `0.3.1` to `1.0.0` in all shipped manifests and the Helm chart.

## Why

OpenShift 4.23+ upgraded multus to CNI spec 1.1.0, which requires delegate plugins to declare `cniVersion >= 0.4.0`. Flannel's manifests still declared `0.3.1`, causing multus to crash on startup:

```
failed to load the primary CNI configuration as a multus delegate
with error 'delegate cni version is 0.3.1 while top level cni version is 1.1.0'
```

## Files changed

- `Documentation/kube-flannel.yml`
- `Documentation/kustomization/kube-flannel/kube-flannel.yml`
- `Documentation/minikube.yml`
- `chart/kube-flannel/values.yaml`

## Why it's safe

- Every supported container runtime accepts 1.0.0 configs (containerd ≥ 1.6, CRI-O ≥ 1.24)
- The flannel CNI plugin ([flannel-io/cni-plugin](https://github.com/flannel-io/cni-plugin)) already supports CNI spec 1.0.0
- Existing pod attachments are unaffected on upgrade: the runtime caches each attachment's config and replays the original `cniVersion` at DEL time

## Reference

- Same fix applied to Calico: [projectcalico/calico#12965](https://github.com/projectcalico/calico/issues/12965), [projectcalico/calico#13352](https://github.com/projectcalico/calico/pull/13352)
- Cilium already shipped 1.1.0 support: [cilium/cilium#37028](https://github.com/cilium/cilium/pull/37028)

## Testing

- [ ] OpenShift 4.23+ with multus 1.1.0 — flannel as primary CNI
- [ ] Standard kubeadm cluster — no regression
- [ ] Upgrade path 0.3.1 → 1.0.0 — existing pods unaffected