### PR TITLE
e2e: add dual-stack (IPv4+IPv6) backend test matrix

### DIFF
--- a/.github/workflows/kind-e2eTests.yml
+++ b/.github/workflows/kind-e2eTests.yml
@@ -15,6 +15,10 @@ jobs:
     name: test
     runs-on: ubuntu-latest
     timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        ip-family: [ipv4, dual]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7.0.1
 
@@ -26,5 +30,18 @@ jobs:
       - name: set up modules
         run: sudo modprobe br_netfilter overlay
 
+      - name: enable IPv6 in Docker
+        if: matrix.ip-family == 'dual'
+        run: |
+          # kind dual-stack clusters need the Docker daemon to have IPv6 enabled.
+          # All flannel IPv6 traffic stays inside the kind Docker network, so the
+          # runner does not need routable/internet IPv6 connectivity.
+          echo '{"ipv6":true,"fixed-cidr-v6":"fd00:dead:beef::/48","ip6tables":true}' \
+            | sudo tee /etc/docker/daemon.json
+          sudo modprobe ip6table_nat ip6table_filter
+          sudo systemctl restart docker
+
       - name: run e2e tests with kind
+        env:
+          IP_FAMILY: ${{ matrix.ip-family == 'dual' && 'dual' || '' }}
         run: make kind-e2e-test

--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ kind-e2e-test: dist/flanneld-$(TAG)-$(ARCH).docker
 	@echo "Building iperf3 image for $(ARCH)..."
 	$(MAKE) -C images/iperf3 ARCH=$(ARCH) || { echo "ERROR: Failed to build iperf3 image for $(ARCH)"; exit 1; }
 	@echo "Running kind e2e tests with Ginkgo..."
-	cd e2e && FLANNEL_IMAGE=$(REGISTRY):$(TAG)-$(ARCH) ARCH=$(ARCH) TAG=$(TAG) \
+	cd e2e && FLANNEL_IMAGE=$(REGISTRY):$(TAG)-$(ARCH) ARCH=$(ARCH) TAG=$(TAG) IP_FAMILY=$(IP_FAMILY) \
 		go test -tags e2e -timeout 60m -v ./...
 
 cover:

--- a/e2e/cluster.go
+++ b/e2e/cluster.go
@@ -47,6 +47,37 @@ var cniPluginSHA256 = map[string]string{
 
 const cniPluginsVersion = "v1.9.1"
 
+// kindNodeImage is the pinned kind node image used for the e2e cluster. It must
+// stay in sync with kind-config.yaml (kept for manual/standalone use).
+const kindNodeImage = "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
+
+// kindConfigYAML renders the kind cluster configuration. When dualStack is set
+// the cluster is configured with ipFamily: dual and both pod subnets so that
+// flannel can hand out IPv4 and IPv6 pod addresses.
+func kindConfigYAML(dualStack bool) string {
+	ipFamily := ""
+	podSubnet := flannelNet
+	if dualStack {
+		ipFamily = "  ipFamily: dual\n"
+		podSubnet = flannelNet + "," + flannelIPv6Net
+	}
+	node := func(role string) string {
+		return fmt.Sprintf(`- role: %s
+  image: %s
+  extraMounts:
+  - hostPath: /opt/cni/bin
+    containerPath: /opt/cni/bin
+`, role, kindNodeImage)
+	}
+	return fmt.Sprintf(`kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+%s  podSubnet: "%s"
+nodes:
+%s%s`, ipFamily, podSubnet, node("control-plane"), node("worker"))
+}
+
 func logf(format string, args ...any) {
 	_, _ = fmt.Fprintf(ginkgo.GinkgoWriter, format, args...)
 }
@@ -147,7 +178,7 @@ func createCluster() (*kindCluster, error) {
 	ginkgo.By("creating kind cluster " + kindClusterName)
 	if err := provider.Create(
 		kindClusterName,
-		cluster.CreateWithConfigFile("kind-config.yaml"),
+		cluster.CreateWithRawConfig([]byte(kindConfigYAML(enableIPv6))),
 		cluster.CreateWithWaitForReady(5*time.Minute),
 	); err != nil {
 		return nil, fmt.Errorf("creating kind cluster: %w", err)

--- a/e2e/connectivity_test.go
+++ b/e2e/connectivity_test.go
@@ -25,18 +25,19 @@ import (
 
 // backendSpec describes a flannel backend under test.
 type backendSpec struct {
-	name      string
-	backend   string // flannel backend type (name without the -nftables suffix)
-	enableNFT bool
-	amd64Only bool
-	hasPerf   bool
+	name         string
+	backend      string // flannel backend type (name without the -nftables suffix)
+	enableNFT    bool
+	amd64Only    bool
+	hasPerf      bool
+	supportsIPv6 bool // included in the dual-stack matrix
 }
 
 var backendSpecs = []backendSpec{
-	{name: "vxlan", backend: "vxlan", hasPerf: true},
-	{name: "vxlan-nftables", backend: "vxlan", enableNFT: true},
-	{name: "wireguard", backend: "wireguard", hasPerf: true},
-	{name: "host-gw", backend: "host-gw", hasPerf: true},
+	{name: "vxlan", backend: "vxlan", hasPerf: true, supportsIPv6: true},
+	{name: "vxlan-nftables", backend: "vxlan", enableNFT: true, supportsIPv6: true},
+	{name: "wireguard", backend: "wireguard", hasPerf: true, supportsIPv6: true},
+	{name: "host-gw", backend: "host-gw", hasPerf: true, supportsIPv6: true},
 	{name: "ipip", backend: "ipip", hasPerf: true},
 	{name: "udp", backend: "udp", amd64Only: true, hasPerf: true},
 }
@@ -47,6 +48,9 @@ var _ = Describe("flannel backends", func() {
 
 		Context(spec.name, Ordered, func() {
 			BeforeAll(func() {
+				if enableIPv6 {
+					Skip("IPv4-only matrix is skipped when IP_FAMILY=dual (covered by the dual-stack matrix)")
+				}
 				if spec.amd64Only && arch != "amd64" {
 					Skip("backend " + spec.backend + " is only tested on amd64")
 				}
@@ -59,7 +63,7 @@ var _ = Describe("flannel backends", func() {
 			})
 
 			It("provides pod-to-pod connectivity", func(ctx SpecContext) {
-				prepareTest(ctx, sharedCluster, spec.backend, spec.enableNFT)
+				prepareTest(ctx, sharedCluster, spec.backend, spec.enableNFT, false)
 				pings(ctx, sharedCluster)
 				sharedCluster.checkRules(ctx, spec.enableNFT)
 				Expect(sharedCluster.deleteFlannel(ctx)).To(Succeed())
@@ -67,7 +71,7 @@ var _ = Describe("flannel backends", func() {
 
 			if spec.hasPerf {
 				It("passes iperf3 throughput test", func(ctx SpecContext) {
-					prepareTest(ctx, sharedCluster, spec.backend, spec.enableNFT)
+					prepareTest(ctx, sharedCluster, spec.backend, spec.enableNFT, false)
 					perf(ctx, sharedCluster)
 					Expect(sharedCluster.deleteFlannel(ctx)).To(Succeed())
 				})
@@ -76,16 +80,48 @@ var _ = Describe("flannel backends", func() {
 	}
 })
 
+var _ = Describe("flannel dual-stack backends", func() {
+	for i := range backendSpecs {
+		spec := backendSpecs[i]
+		if !spec.supportsIPv6 {
+			continue
+		}
+
+		Context(spec.name, Ordered, func() {
+			BeforeAll(func() {
+				if !enableIPv6 {
+					Skip("dual-stack matrix is disabled; set IP_FAMILY=dual (requires Docker IPv6)")
+				}
+			})
+
+			AfterEach(func(ctx SpecContext) {
+				if CurrentSpecReport().Failed() {
+					sharedCluster.dumpDebugInfo(ctx)
+				}
+			})
+
+			It("provides dual-stack pod-to-pod connectivity", func(ctx SpecContext) {
+				prepareTest(ctx, sharedCluster, spec.backend, spec.enableNFT, true)
+				pings(ctx, sharedCluster)
+				pingsV6(ctx, sharedCluster)
+				sharedCluster.checkRules(ctx, spec.enableNFT)
+				sharedCluster.checkRulesV6(ctx, spec.enableNFT)
+				Expect(sharedCluster.deleteFlannel(ctx)).To(Succeed())
+			})
+		})
+	}
+})
+
 // prepareTest installs flannel and waits for the cluster to be ready, mirroring
 // the bash prepare_test function.
-func prepareTest(ctx context.Context, kc *kindCluster, backend string, enableNFT bool) {
+func prepareTest(ctx context.Context, kc *kindCluster, backend string, enableNFT, enableIPv6 bool) {
 	GinkgoHelper()
 
 	By("cleaning up test pods from prior spec")
 	Expect(kc.deleteTestPods(ctx)).To(Succeed())
 
 	By("installing flannel with backend " + backend)
-	Expect(kc.installFlannel(ctx, backend, enableNFT)).To(Succeed())
+	Expect(kc.installFlannel(ctx, backend, enableNFT, enableIPv6)).To(Succeed())
 
 	By("waiting for the flannel DaemonSet to roll out")
 	Expect(kc.waitForFlannelRollout(ctx, 5*time.Minute)).To(Succeed())
@@ -124,6 +160,25 @@ func pings(ctx context.Context, kc *kindCluster) {
 	Expect(err).NotTo(HaveOccurred(), "multitool1 cannot ping multitool2")
 	_, err = kc.execInPod(ctx, "default", "multitool2", "ping", "-c", "5", ip1)
 	Expect(err).NotTo(HaveOccurred(), "multitool2 cannot ping multitool1")
+}
+
+// pingsV6 verifies bidirectional IPv6 connectivity between the two test pods
+// created by pings. It assumes pings has already created multitool1/multitool2.
+func pingsV6(ctx context.Context, kc *kindCluster) {
+	GinkgoHelper()
+
+	ip1, err := kc.podIPv6(ctx, "multitool1")
+	Expect(err).NotTo(HaveOccurred())
+	ip2, err := kc.podIPv6(ctx, "multitool2")
+	Expect(err).NotTo(HaveOccurred())
+	By("multitool1(v6)=" + ip1 + " multitool2(v6)=" + ip2)
+
+	Expect(kc.waitForPing6(ctx, "multitool1", ip2, time.Minute)).To(Succeed())
+
+	_, err = kc.execInPod(ctx, "default", "multitool1", "ping", "-6", "-c", "5", ip2)
+	Expect(err).NotTo(HaveOccurred(), "multitool1 cannot ping6 multitool2")
+	_, err = kc.execInPod(ctx, "default", "multitool2", "ping", "-6", "-c", "5", ip1)
+	Expect(err).NotTo(HaveOccurred(), "multitool2 cannot ping6 multitool1")
 }
 
 // perf runs an iperf3 throughput test between two pods, mirroring the bash perf

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -29,13 +29,23 @@
 //	TAG              image tag used to build FLANNEL_IMAGE               (git describe)
 //	FLANNEL_IMAGE    full flannel image ref (quay.io/coreos/flannel:$TAG-$ARCH)
 //	FLANNEL_NET      IPv4 pod network                                    (10.42.0.0/16)
+//	FLANNEL_IPV6_NET IPv6 pod network (dual-stack runs)                  (fd00:10:244::/56)
+//	IP_FAMILY        set to "dual" to run the dual-stack backend matrix  (ipv4)
 //	IPERF3_IMAGE     iperf3 image reference                              (iperf3:latest)
 //	MULTITOOL_IMAGE  connectivity test image           (wbitt/network-multitool:alpine-extra)
+//
+// The dual-stack matrix (IP_FAMILY=dual) requires the Docker daemon on the host
+// to have IPv6 enabled (ipv6 + fixed-cidr-v6 + ip6tables in daemon.json). All
+// flannel IPv6 traffic stays inside the kind Docker network, so the host does
+// not need routable/internet IPv6 connectivity; GitHub-hosted runners work once
+// the daemon is configured. When IP_FAMILY=dual the IPv4-only matrix is skipped
+// (its IPv4 assertions are covered by the dual-stack specs).
 package e2e
 
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -61,6 +71,8 @@ var (
 	iperf3Image    string
 	multitoolImage string
 	flannelNet     string
+	flannelIPv6Net string
+	enableIPv6     bool
 )
 
 func env(key, def string) string {
@@ -78,6 +90,8 @@ func TestE2E(t *testing.T) {
 var _ = BeforeSuite(func() {
 	arch = env("ARCH", "amd64")
 	flannelNet = env("FLANNEL_NET", "10.42.0.0/16")
+	flannelIPv6Net = env("FLANNEL_IPV6_NET", "fd00:10:244::/56")
+	enableIPv6 = strings.EqualFold(os.Getenv("IP_FAMILY"), "dual")
 	iperf3Image = env("IPERF3_IMAGE", "iperf3:latest")
 	multitoolImage = env("MULTITOOL_IMAGE", "wbitt/network-multitool:alpine-extra")
 
@@ -89,7 +103,7 @@ var _ = BeforeSuite(func() {
 		flannelImage = fmt.Sprintf("quay.io/coreos/flannel:%s-%s", tag, arch)
 	}
 
-	By(fmt.Sprintf("using flannel image %s (arch %s)", flannelImage, arch))
+	By(fmt.Sprintf("using flannel image %s (arch %s, dual-stack %t)", flannelImage, arch, enableIPv6))
 
 	// CNI plugins must be present on the host so the kind nodes can wire pods.
 	Expect(installCNIPlugins(arch)).To(Succeed(), "installing CNI plugins")

--- a/e2e/flannel.go
+++ b/e2e/flannel.go
@@ -61,8 +61,8 @@ func dynamicResource(dyn dynamic.Interface, gvr schema.GroupVersionResource, nam
 // the flannel image, net-conf.json and, for the udp backend, the privileged
 // flag) and applies it via the dynamic client. It replaces write-flannel-conf +
 // install-flannel. The list of created objects is stored for later deletion.
-func (kc *kindCluster) installFlannel(ctx context.Context, backend string, enableNFTables bool) error {
-	objs, err := renderFlannelManifest(backend, enableNFTables)
+func (kc *kindCluster) installFlannel(ctx context.Context, backend string, enableNFTables, enableIPv6 bool) error {
+	objs, err := renderFlannelManifest(backend, enableNFTables, enableIPv6)
 	if err != nil {
 		return err
 	}
@@ -185,7 +185,7 @@ func (kc *kindCluster) restMapper() (meta.RESTMapper, error) {
 }
 
 // renderFlannelManifest loads the shipped manifest and patches it in place.
-func renderFlannelManifest(backend string, enableNFTables bool) ([]*unstructured.Unstructured, error) {
+func renderFlannelManifest(backend string, enableNFTables, enableIPv6 bool) ([]*unstructured.Unstructured, error) {
 	raw, err := os.ReadFile(flannelManifestPath)
 	if err != nil {
 		return nil, err
@@ -195,10 +195,18 @@ func renderFlannelManifest(backend string, enableNFTables bool) ([]*unstructured
 		return nil, err
 	}
 
-	netConf := fmt.Sprintf(
-		`{ "Network": "%s", "Backend": { "Type": "%s" }, "EnableNFTables": %t }`,
-		flannelNet, backend, enableNFTables,
-	)
+	var netConf string
+	if enableIPv6 {
+		netConf = fmt.Sprintf(
+			`{ "Network": "%s", "IPv6Network": "%s", "EnableIPv6": true, "Backend": { "Type": "%s" }, "EnableNFTables": %t }`,
+			flannelNet, flannelIPv6Net, backend, enableNFTables,
+		)
+	} else {
+		netConf = fmt.Sprintf(
+			`{ "Network": "%s", "Backend": { "Type": "%s" }, "EnableNFTables": %t }`,
+			flannelNet, backend, enableNFTables,
+		)
+	}
 
 	for _, obj := range objs {
 		switch obj.GetKind() {

--- a/e2e/kind-config.yaml
+++ b/e2e/kind-config.yaml
@@ -1,5 +1,9 @@
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
+# NOTE: The e2e suite generates its kind config in code (see kindConfigYAML in
+# cluster.go) so it can toggle dual-stack via IP_FAMILY. This file is kept as an
+# IPv4 reference for running kind manually and must stay in sync with the image
+# pinned in cluster.go (kindNodeImage).
 networking:
   disableDefaultCNI: true
   podSubnet: "10.42.0.0/16"

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -131,6 +132,34 @@ func (kc *kindCluster) podCIDR(ctx context.Context, node string) (string, error)
 	return n.Spec.PodCIDR, nil
 }
 
+// podCIDRv6 returns the node's IPv6 pod CIDR from Spec.PodCIDRs (dual-stack).
+func (kc *kindCluster) podCIDRv6(ctx context.Context, node string) (string, error) {
+	n, err := kc.client.CoreV1().Nodes().Get(ctx, node, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, cidr := range n.Spec.PodCIDRs {
+		if strings.Contains(cidr, ":") {
+			return cidr, nil
+		}
+	}
+	return "", fmt.Errorf("node %s has no IPv6 pod CIDR (PodCIDRs=%v)", node, n.Spec.PodCIDRs)
+}
+
+// podIPv6 returns the pod's IPv6 address from Status.PodIPs (dual-stack).
+func (kc *kindCluster) podIPv6(ctx context.Context, name string) (string, error) {
+	pod, err := kc.client.CoreV1().Pods("default").Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	for _, podIP := range pod.Status.PodIPs {
+		if strings.Contains(podIP.IP, ":") {
+			return podIP.IP, nil
+		}
+	}
+	return "", fmt.Errorf("pod %s has no IPv6 address (PodIPs=%v)", name, pod.Status.PodIPs)
+}
+
 // execInPod runs a command in a pod's default container and returns
 // stdout+stderr, replacing `kubectl exec`.
 func (kc *kindCluster) execInPod(ctx context.Context, namespace, pod string, command ...string) (string, error) {
@@ -221,6 +250,14 @@ func (kc *kindCluster) waitForCoreDNS(ctx context.Context, timeout time.Duration
 func (kc *kindCluster) waitForPing(ctx context.Context, pod, ip string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		_, err := kc.execInPod(ctx, "default", pod, "ping", "-c", "1", ip)
+		return err == nil, nil
+	})
+}
+
+// waitForPing6 is the IPv6 counterpart of waitForPing.
+func (kc *kindCluster) waitForPing6(ctx context.Context, pod, ip string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		_, err := kc.execInPod(ctx, "default", pod, "ping", "-6", "-c", "1", ip)
 		return err == nil, nil
 	})
 }

--- a/e2e/rules.go
+++ b/e2e/rules.go
@@ -39,19 +39,37 @@ func writeln(w io.Writer, args ...any) {
 // expectedIptablesPostrouting builds the golden FLANNEL-POSTRTG rule set for a
 // node with the given pod CIDR, mirroring check_iptables.
 func expectedIptablesPostrouting(podCIDR string) string {
+	return iptablesPostroutingRules(podCIDR, flannelNet, "224.0.0.0/4")
+}
+
+// expectedIp6tablesPostrouting is the IPv6 counterpart (ff00::/8 multicast).
+func expectedIp6tablesPostrouting(podCIDR string) string {
+	return iptablesPostroutingRules(podCIDR, flannelIPv6Net, "ff00::/8")
+}
+
+func iptablesPostroutingRules(podCIDR, network, multicast string) string {
 	return strings.Join([]string{
 		`-A POSTROUTING -m comment --comment "flanneld masq" -j FLANNEL-POSTRTG`,
 		`-N FLANNEL-POSTRTG`,
 		`-A FLANNEL-POSTRTG -m mark --mark 0x4000/0x4000 -m comment --comment "flanneld masq" -j RETURN`,
-		fmt.Sprintf(`-A FLANNEL-POSTRTG -s %s -d %s -m comment --comment "flanneld masq" -j RETURN`, podCIDR, flannelNet),
-		fmt.Sprintf(`-A FLANNEL-POSTRTG -s %s -d %s -m comment --comment "flanneld masq" -j RETURN`, flannelNet, podCIDR),
-		fmt.Sprintf(`-A FLANNEL-POSTRTG ! -s %s -d %s -m comment --comment "flanneld masq" -j RETURN`, flannelNet, podCIDR),
-		fmt.Sprintf(`-A FLANNEL-POSTRTG -s %s ! -d 224.0.0.0/4 -m comment --comment "flanneld masq" -j MASQUERADE --random-fully`, flannelNet),
-		fmt.Sprintf(`-A FLANNEL-POSTRTG ! -s %s -d %s -m comment --comment "flanneld masq" -j MASQUERADE --random-fully`, flannelNet, flannelNet),
+		fmt.Sprintf(`-A FLANNEL-POSTRTG -s %s -d %s -m comment --comment "flanneld masq" -j RETURN`, podCIDR, network),
+		fmt.Sprintf(`-A FLANNEL-POSTRTG -s %s -d %s -m comment --comment "flanneld masq" -j RETURN`, network, podCIDR),
+		fmt.Sprintf(`-A FLANNEL-POSTRTG ! -s %s -d %s -m comment --comment "flanneld masq" -j RETURN`, network, podCIDR),
+		fmt.Sprintf(`-A FLANNEL-POSTRTG -s %s ! -d %s -m comment --comment "flanneld masq" -j MASQUERADE --random-fully`, network, multicast),
+		fmt.Sprintf(`-A FLANNEL-POSTRTG ! -s %s -d %s -m comment --comment "flanneld masq" -j MASQUERADE --random-fully`, network, network),
 	}, "\n")
 }
 
 func expectedIptablesForward() string {
+	return iptablesForwardRules(flannelNet)
+}
+
+// expectedIp6tablesForward is the IPv6 counterpart of expectedIptablesForward.
+func expectedIp6tablesForward() string {
+	return iptablesForwardRules(flannelIPv6Net)
+}
+
+func iptablesForwardRules(network string) string {
 	return strings.Join([]string{
 		`-P FORWARD ACCEPT`,
 		`-A FORWARD -m conntrack --ctstate NEW -m comment --comment "kubernetes load balancer firewall" -j KUBE-PROXY-FIREWALL`,
@@ -60,8 +78,8 @@ func expectedIptablesForward() string {
 		`-A FORWARD -m conntrack --ctstate NEW -m comment --comment "kubernetes externally-visible service portals" -j KUBE-EXTERNAL-SERVICES`,
 		`-A FORWARD -m comment --comment "flanneld forward" -j FLANNEL-FWD`,
 		`-N FLANNEL-FWD`,
-		fmt.Sprintf(`-A FLANNEL-FWD -s %s -m comment --comment "flanneld forward" -j ACCEPT`, flannelNet),
-		fmt.Sprintf(`-A FLANNEL-FWD -d %s -m comment --comment "flanneld forward" -j ACCEPT`, flannelNet),
+		fmt.Sprintf(`-A FLANNEL-FWD -s %s -m comment --comment "flanneld forward" -j ACCEPT`, network),
+		fmt.Sprintf(`-A FLANNEL-FWD -d %s -m comment --comment "flanneld forward" -j ACCEPT`, network),
 	}, "\n")
 }
 
@@ -72,6 +90,15 @@ func (kc *kindCluster) checkRules(ctx context.Context, enableNFT bool) {
 		kc.checkNftables(ctx)
 	} else {
 		kc.checkIptables(ctx)
+	}
+}
+
+// checkRulesV6 asserts flannel's IPv6 masquerade and forward rules on both nodes.
+func (kc *kindCluster) checkRulesV6(ctx context.Context, enableNFT bool) {
+	if enableNFT {
+		kc.checkNftablesV6(ctx)
+	} else {
+		kc.checkIp6tables(ctx)
 	}
 }
 
@@ -86,21 +113,42 @@ func (kc *kindCluster) nodeCIDRs(ctx context.Context) map[string]string {
 	return cidrs
 }
 
+// nodeCIDRsV6 returns the IPv6 pod CIDR of each node keyed by node name.
+func (kc *kindCluster) nodeCIDRsV6(ctx context.Context) map[string]string {
+	cidrs := map[string]string{}
+	for _, node := range []string{kindWorker, kindControlPlane} {
+		cidr, err := kc.podCIDRv6(ctx, node)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		cidrs[node] = cidr
+	}
+	return cidrs
+}
+
 // checkIptables asserts the masquerade and forward rules on both nodes, mirroring
 // the bash check_iptables helper.
 func (kc *kindCluster) checkIptables(ctx context.Context) {
 	for node, cidr := range kc.nodeCIDRs(ctx) {
-		gomega.Expect(kc.iptablesNatFlannel(node)).To(gomega.Equal(expectedIptablesPostrouting(cidr)),
+		gomega.Expect(kc.iptablesNatFlannel(node, "/usr/sbin/iptables")).To(gomega.Equal(expectedIptablesPostrouting(cidr)),
 			"node %s has unexpected postrouting rules", node)
-		gomega.Expect(kc.iptablesFilterForward(node)).To(gomega.Equal(expectedIptablesForward()),
+		gomega.Expect(kc.iptablesFilterForward(node, "/usr/sbin/iptables")).To(gomega.Equal(expectedIptablesForward()),
 			"node %s has unexpected forward rules", node)
 	}
 }
 
-func (kc *kindCluster) iptablesNatFlannel(node string) string {
-	post, err := kc.execOnNode(node, "/usr/sbin/iptables", "-t", "nat", "-S", "POSTROUTING")
+// checkIp6tables asserts the IPv6 masquerade and forward rules on both nodes.
+func (kc *kindCluster) checkIp6tables(ctx context.Context) {
+	for node, cidr := range kc.nodeCIDRsV6(ctx) {
+		gomega.Expect(kc.iptablesNatFlannel(node, "/usr/sbin/ip6tables")).To(gomega.Equal(expectedIp6tablesPostrouting(cidr)),
+			"node %s has unexpected IPv6 postrouting rules", node)
+		gomega.Expect(kc.iptablesFilterForward(node, "/usr/sbin/ip6tables")).To(gomega.Equal(expectedIp6tablesForward()),
+			"node %s has unexpected IPv6 forward rules", node)
+	}
+}
+
+func (kc *kindCluster) iptablesNatFlannel(node, bin string) string {
+	post, err := kc.execOnNode(node, bin, "-t", "nat", "-S", "POSTROUTING")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	chain, err := kc.execOnNode(node, "/usr/sbin/iptables", "-t", "nat", "-S", "FLANNEL-POSTRTG")
+	chain, err := kc.execOnNode(node, bin, "-t", "nat", "-S", "FLANNEL-POSTRTG")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	var lines []string
@@ -113,10 +161,10 @@ func (kc *kindCluster) iptablesNatFlannel(node string) string {
 	return strings.Join(lines, "\n")
 }
 
-func (kc *kindCluster) iptablesFilterForward(node string) string {
-	fwd, err := kc.execOnNode(node, "/usr/sbin/iptables", "-t", "filter", "-S", "FORWARD")
+func (kc *kindCluster) iptablesFilterForward(node, bin string) string {
+	fwd, err := kc.execOnNode(node, bin, "-t", "filter", "-S", "FORWARD")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
-	chain, err := kc.execOnNode(node, "/usr/sbin/iptables", "-t", "filter", "-S", "FLANNEL-FWD")
+	chain, err := kc.execOnNode(node, bin, "-t", "filter", "-S", "FLANNEL-FWD")
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 	return strings.TrimRight(fwd, "\n") + "\n" + strings.TrimRight(chain, "\n")
 }
@@ -165,6 +213,53 @@ func (kc *kindCluster) checkNftables(ctx context.Context) {
 		gomega.Expect(err).NotTo(gomega.HaveOccurred())
 		gomega.Expect(strings.TrimRight(fwd, "\n")).To(gomega.Equal(expectedNftForward()),
 			"node %s has unexpected nftables forward rules", node)
+	}
+}
+
+// expectedNft6Postrouting builds the golden nftables postrtg chain for the IPv6
+// family (table ip6 flannel-ipv6), mirroring addMasqRules with ff00::/8.
+func expectedNft6Postrouting(podCIDR string) string {
+	return strings.Join([]string{
+		`table ip6 flannel-ipv6 {`,
+		"\tchain postrtg {",
+		"\t\tcomment \"chain to manage traffic masquerading by flannel\"",
+		"\t\ttype nat hook postrouting priority srcnat; policy accept;",
+		"\t\tmeta mark 0x00004000 return",
+		fmt.Sprintf("\t\tip6 saddr %s ip6 daddr %s return", podCIDR, flannelIPv6Net),
+		fmt.Sprintf("\t\tip6 saddr %s ip6 daddr %s return", flannelIPv6Net, podCIDR),
+		fmt.Sprintf("\t\tip6 saddr != %s ip6 daddr %s return", podCIDR, flannelIPv6Net),
+		fmt.Sprintf("\t\tip6 saddr %s ip6 daddr != ff00::/8 masquerade fully-random", flannelIPv6Net),
+		fmt.Sprintf("\t\tip6 saddr != %s ip6 daddr %s masquerade fully-random", flannelIPv6Net, flannelIPv6Net),
+		"\t}",
+		`}`,
+	}, "\n")
+}
+
+func expectedNft6Forward() string {
+	return strings.Join([]string{
+		`table ip6 flannel-ipv6 {`,
+		"\tchain forward {",
+		"\t\tcomment \"chain to accept flannel traffic\"",
+		"\t\ttype filter hook forward priority filter; policy accept;",
+		fmt.Sprintf("\t\tip6 saddr %s accept", flannelIPv6Net),
+		fmt.Sprintf("\t\tip6 daddr %s accept", flannelIPv6Net),
+		"\t}",
+		`}`,
+	}, "\n")
+}
+
+// checkNftablesV6 asserts the IPv6 nftables masquerade and forward chains.
+func (kc *kindCluster) checkNftablesV6(ctx context.Context) {
+	for node, cidr := range kc.nodeCIDRsV6(ctx) {
+		post, err := kc.execOnNode(node, "/usr/sbin/nft", "list", "chain", "ip6", "flannel-ipv6", "postrtg")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(strings.TrimRight(post, "\n")).To(gomega.Equal(expectedNft6Postrouting(cidr)),
+			"node %s has unexpected IPv6 nftables postrouting rules", node)
+
+		fwd, err := kc.execOnNode(node, "/usr/sbin/nft", "list", "chain", "ip6", "flannel-ipv6", "forward")
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+		gomega.Expect(strings.TrimRight(fwd, "\n")).To(gomega.Equal(expectedNft6Forward()),
+			"node %s has unexpected IPv6 nftables forward rules", node)
 	}
 }
 


### PR DESCRIPTION
## What

Extends the kind-based e2e suite (`e2e/`) with a **dual-stack (IPv4+IPv6)** test matrix, increasing coverage of flannel's IPv6 path which was previously untested end-to-end.

The dual-stack matrix runs the IPv6-capable backends — `vxlan`, `vxlan-nftables`, `wireguard`, `host-gw` — and asserts both IPv4 **and** IPv6 pod-to-pod connectivity plus the golden masquerade/forward rules for both families.

## How

- **kind config generated in code** (`kindConfigYAML` in `cluster.go`, via `CreateWithRawConfig`): `IP_FAMILY=dual` produces `ipFamily: dual` + a dual `podSubnet`. The static `kind-config.yaml` is kept as an IPv4 reference for running kind manually.
- **net-conf.json**: `installFlannel`/`renderFlannelManifest` inject `IPv6Network` + `EnableIPv6` when dual-stack.
- **New specs** (`connectivity_test.go`): a `flannel dual-stack backends` Describe that pings over v4 and v6 and checks v4+v6 rules. The IPv4-only matrix is **skipped** when `IP_FAMILY=dual` (its IPv4 assertions are covered by the dual-stack specs) to keep runtime bounded.
- **Golden IPv6 rules** (`rules.go`): `ip6tables` and `nft ip6 flannel-ipv6` postrouting/forward assertions mirrored from the `trafficmngr` source (`ff00::/8` multicast, `ip6 saddr/daddr`).
- **Helpers** (`kube.go`): `podCIDRv6`, `podIPv6`, `waitForPing6`.

## CI

`kind-e2eTests.yml` now uses an `ip-family: [ipv4, dual]` matrix. The `dual` leg enables IPv6 in the Docker daemon (`ipv6` + `fixed-cidr-v6` + `ip6tables` in `daemon.json`, plus `ip6table_nat`/`ip6table_filter`) before creating the cluster.

**Why this works on GitHub-hosted runners:** all flannel IPv6 traffic stays inside the kind Docker network (node containers on a Docker bridge), so the runner does **not** need routable/internet IPv6 connectivity — only the Docker daemon's internal IPv6 enabled. This is dual-stack (not v6-only), since the control plane and image pulls still use IPv4.

## Validation

- `gofmt` clean; `go vet -tags e2e ./...` passes.
- Generated kind YAML validated to parse for both the ipv4 and dual variants.

## Notes / risk

I could not run the full kind suite locally (needs Docker + kind + IPv6), so the golden IPv6 rule strings are derived from flannel's source rather than observed output. The IPv6 `FORWARD`-chain assertion assumes kube-proxy programs `ip6tables` identically to IPv4 — the same assumption the existing IPv4 test already makes. The first CI run on the `dual` leg is the real validation and may surface a minor rule-text tweak.