### PR TITLE
e2e: add Service and CoreDNS connectivity test

### DIFF
--- a/e2e/dns_test.go
+++ b/e2e/dns_test.go
@@ -98,17 +98,33 @@ var _ = Describe("flannel service and DNS", Ordered, func() {
 	})
 })
 
-// waitForDNS polls until nslookup of host from pod succeeds, mirroring the style
-// of waitForPing.
+// waitForDNS polls until nslookup of host from pod returns an answer section,
+// mirroring the style of waitForPing.
 func (kc *kindCluster) waitForDNS(ctx context.Context, pod, host string, timeout time.Duration) error {
 	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
 		out, err := kc.execInPod(ctx, "default", pod, "nslookup", host)
 		if err != nil {
 			return false, nil
 		}
-		// nslookup prints "server can't find" on failure even with exit 0 on
-		// some images, so require an Address line for the answer section.
-		return strings.Contains(out, "Address"), nil
+		lowerOut := strings.ToLower(out)
+		for _, failure := range []string{"can't resolve", "can't find", "nxdomain", "no answer", "server can't"} {
+			if strings.Contains(lowerOut, failure) {
+				return false, nil
+			}
+		}
+
+		seenName := false
+		for _, line := range strings.Split(out, "\n") {
+			line = strings.TrimSpace(line)
+			if strings.HasPrefix(line, "Name:") {
+				seenName = true
+				continue
+			}
+			if seenName && line != "" && strings.Contains(line, "Address") {
+				return true, nil
+			}
+		}
+		return false, nil
 	})
 }
 

--- a/e2e/dns_test.go
+++ b/e2e/dns_test.go
@@ -1,0 +1,126 @@
+//go:build e2e
+
+// Copyright 2026 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package e2e
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// The service/DNS spec exercises a ClusterIP Service backed by a multi-replica
+// Deployment plus CoreDNS resolution over the flannel network. It uses a single
+// cheap backend (vxlan, iptables) since its purpose is to validate service
+// routing and cluster DNS rather than the full backend matrix. It assumes
+// CoreDNS and kube-proxy are healthy in the shared cluster.
+var _ = Describe("flannel service and DNS", Ordered, func() {
+	const (
+		deploymentName = "dns-web"
+		serviceName    = "dns-web"
+		clientPod      = "dns-client"
+		servicePort    = int32(80)
+		fqdn           = "dns-web.default.svc.cluster.local"
+	)
+
+	BeforeAll(func() {
+		if enableIPv6 {
+			Skip("service/DNS spec runs on the IPv4-only matrix (skipped when IP_FAMILY=dual)")
+		}
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		if CurrentSpecReport().Failed() {
+			sharedCluster.dumpDebugInfo(ctx)
+		}
+	})
+
+	AfterAll(func(ctx SpecContext) {
+		By("cleaning up service/DNS test resources")
+		Expect(sharedCluster.deletePod(ctx, "default", clientPod)).To(Succeed())
+		Expect(sharedCluster.deleteService(ctx, "default", serviceName)).To(Succeed())
+		Expect(sharedCluster.deleteDeployment(ctx, "default", deploymentName)).To(Succeed())
+		Expect(sharedCluster.deleteFlannel(ctx)).To(Succeed())
+	})
+
+	It("resolves and reaches a ClusterIP service across nodes", func(ctx SpecContext) {
+		prepareTest(ctx, sharedCluster, "vxlan", false, false)
+
+		By("creating the backend deployment spread across nodes")
+		Expect(sharedCluster.createDeployment(ctx, deploymentName, multitoolImage, 2, servicePort, "")).To(Succeed())
+		Expect(sharedCluster.waitForDeploymentReady(ctx, "default", deploymentName, 2*time.Minute)).To(Succeed())
+
+		By("creating the ClusterIP service")
+		Expect(sharedCluster.createClusterIPService(ctx, serviceName,
+			map[string]string{"app": deploymentName}, servicePort, servicePort)).To(Succeed())
+		clusterIP, err := sharedCluster.serviceClusterIP(ctx, "default", serviceName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(clusterIP).NotTo(BeEmpty())
+		By("service " + serviceName + " ClusterIP=" + clusterIP)
+
+		By("creating the client pod on the control-plane node")
+		Expect(sharedCluster.createTestPod(ctx, clientPod, kindControlPlane)).To(Succeed())
+		Expect(sharedCluster.waitForPodReady(ctx, "default", clientPod, time.Minute)).To(Succeed())
+
+		By("resolving kubernetes.default via CoreDNS")
+		Expect(sharedCluster.waitForDNS(ctx, clientPod, "kubernetes.default", time.Minute)).
+			To(Succeed(), "CoreDNS did not resolve kubernetes.default over the flannel network")
+
+		By("resolving the service FQDN to its ClusterIP")
+		out, err := sharedCluster.execInPod(ctx, "default", clientPod, "nslookup", fqdn)
+		Expect(err).NotTo(HaveOccurred(), "nslookup %s failed: %s", fqdn, out)
+		Expect(out).To(ContainSubstring(clusterIP),
+			"nslookup did not return the service ClusterIP %s:\n%s", clusterIP, out)
+
+		By("curling the service by DNS name")
+		Expect(sharedCluster.waitForHTTPOK(ctx, clientPod, "http://"+fqdn, time.Minute)).
+			To(Succeed(), "service was not reachable by DNS name over the flannel network")
+
+		By("curling the service by raw ClusterIP")
+		Expect(sharedCluster.waitForHTTPOK(ctx, clientPod, "http://"+clusterIP, time.Minute)).
+			To(Succeed(), "service was not reachable by ClusterIP over the flannel network")
+	})
+})
+
+// waitForDNS polls until nslookup of host from pod succeeds, mirroring the style
+// of waitForPing.
+func (kc *kindCluster) waitForDNS(ctx context.Context, pod, host string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		out, err := kc.execInPod(ctx, "default", pod, "nslookup", host)
+		if err != nil {
+			return false, nil
+		}
+		// nslookup prints "server can't find" on failure even with exit 0 on
+		// some images, so require an Address line for the answer section.
+		return strings.Contains(out, "Address"), nil
+	})
+}
+
+// waitForHTTPOK polls until an HTTP GET of url from pod returns 200, mirroring
+// the style of waitForPing. kube-proxy and pod readiness race, so this retries.
+func (kc *kindCluster) waitForHTTPOK(ctx context.Context, pod, url string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 2*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		out, err := kc.execInPod(ctx, "default", pod,
+			"curl", "-sS", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", "5", url)
+		if err != nil {
+			return false, nil
+		}
+		return strings.TrimSpace(out) == "200", nil
+	})
+}

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -22,9 +22,11 @@ import (
 	"strings"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
@@ -275,6 +277,123 @@ func (kc *kindCluster) waitForSubnetEnv(ctx context.Context, timeout time.Durati
 		}
 		out, _ := kc.execOnNode(node, "cat", "/run/flannel/subnet.env")
 		logf("subnet.env on %s:\n%s\n", node, out)
+	}
+	return nil
+}
+
+// createDeployment creates a Deployment in the default namespace serving on the
+// given container port. Replicas are spread across nodes via a pod anti-affinity
+// rule so that pod-to-service traffic must cross the flannel overlay. When node
+// is non-empty the pods are additionally pinned to that node.
+func (kc *kindCluster) createDeployment(ctx context.Context, name, image string, replicas int32, port int32, node string) error {
+	labels := map[string]string{"app": name}
+	spec := corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name:            name,
+			Image:           image,
+			ImagePullPolicy: corev1.PullIfNotPresent,
+			Ports:           []corev1.ContainerPort{{ContainerPort: port}},
+		}},
+		Affinity: &corev1.Affinity{
+			PodAntiAffinity: &corev1.PodAntiAffinity{
+				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
+					Weight: 100,
+					PodAffinityTerm: corev1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{MatchLabels: labels},
+						TopologyKey:   "kubernetes.io/hostname",
+					},
+				}},
+			},
+		},
+	}
+	if node != "" {
+		spec.NodeName = node
+	}
+
+	dep := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Labels: labels},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &replicas,
+			Selector: &metav1.LabelSelector{MatchLabels: labels},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+				Spec:       spec,
+			},
+		},
+	}
+	_, err := kc.client.AppsV1().Deployments("default").Create(ctx, dep, metav1.CreateOptions{})
+	return err
+}
+
+// createClusterIPService creates a ClusterIP Service in the default namespace
+// selecting pods by the given selector.
+func (kc *kindCluster) createClusterIPService(ctx context.Context, name string, selector map[string]string, port, targetPort int32) error {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: corev1.ServiceSpec{
+			Type:     corev1.ServiceTypeClusterIP,
+			Selector: selector,
+			Ports: []corev1.ServicePort{{
+				Port:       port,
+				TargetPort: intstr.FromInt32(targetPort),
+				Protocol:   corev1.ProtocolTCP,
+			}},
+		},
+	}
+	_, err := kc.client.CoreV1().Services("default").Create(ctx, svc, metav1.CreateOptions{})
+	return err
+}
+
+// serviceClusterIP returns the allocated ClusterIP of a Service.
+func (kc *kindCluster) serviceClusterIP(ctx context.Context, namespace, name string) (string, error) {
+	svc, err := kc.client.CoreV1().Services(namespace).Get(ctx, name, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+	return svc.Spec.ClusterIP, nil
+}
+
+// waitForDeploymentReady polls until all replicas of the Deployment are ready.
+func (kc *kindCluster) waitForDeploymentReady(ctx context.Context, namespace, name string, timeout time.Duration) error {
+	return wait.PollUntilContextTimeout(ctx, 3*time.Second, timeout, true, func(ctx context.Context) (bool, error) {
+		dep, err := kc.client.AppsV1().Deployments(namespace).Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, nil
+		}
+		desired := int32(1)
+		if dep.Spec.Replicas != nil {
+			desired = *dep.Spec.Replicas
+		}
+		return dep.Status.ReadyReplicas >= desired, nil
+	})
+}
+
+// deleteDeployment removes a Deployment, ignoring NotFound.
+func (kc *kindCluster) deleteDeployment(ctx context.Context, namespace, name string) error {
+	err := kc.client.AppsV1().Deployments(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting deployment %s: %w", name, err)
+	}
+	return nil
+}
+
+// deleteService removes a Service, ignoring NotFound.
+func (kc *kindCluster) deleteService(ctx context.Context, namespace, name string) error {
+	err := kc.client.CoreV1().Services(namespace).Delete(ctx, name, metav1.DeleteOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting service %s: %w", name, err)
+	}
+	return nil
+}
+
+// deletePod removes a single pod immediately, ignoring NotFound.
+func (kc *kindCluster) deletePod(ctx context.Context, namespace, name string) error {
+	gracePeriodSeconds := int64(0)
+	err := kc.client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriodSeconds,
+	})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting pod %s: %w", name, err)
 	}
 	return nil
 }

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -282,9 +282,11 @@ func (kc *kindCluster) waitForSubnetEnv(ctx context.Context, timeout time.Durati
 }
 
 // createDeployment creates a Deployment in the default namespace serving on the
-// given container port. Replicas are spread across nodes via a pod anti-affinity
-// rule so that pod-to-service traffic must cross the flannel overlay. When node
-// is non-empty the pods are additionally pinned to that node.
+// given container port. Replicas are guaranteed to spread across nodes via a
+// required pod anti-affinity rule so that pod-to-service traffic must cross the
+// flannel overlay. The control-plane NoSchedule taint is tolerated so a replica
+// can run there in the default kind cluster. When node is non-empty the pods are
+// additionally pinned to that node.
 func (kc *kindCluster) createDeployment(ctx context.Context, name, image string, replicas int32, port int32, node string) error {
 	labels := map[string]string{"app": name}
 	spec := corev1.PodSpec{
@@ -296,15 +298,17 @@ func (kc *kindCluster) createDeployment(ctx context.Context, name, image string,
 		}},
 		Affinity: &corev1.Affinity{
 			PodAntiAffinity: &corev1.PodAntiAffinity{
-				PreferredDuringSchedulingIgnoredDuringExecution: []corev1.WeightedPodAffinityTerm{{
-					Weight: 100,
-					PodAffinityTerm: corev1.PodAffinityTerm{
-						LabelSelector: &metav1.LabelSelector{MatchLabels: labels},
-						TopologyKey:   "kubernetes.io/hostname",
-					},
+				RequiredDuringSchedulingIgnoredDuringExecution: []corev1.PodAffinityTerm{{
+					LabelSelector: &metav1.LabelSelector{MatchLabels: labels},
+					TopologyKey:   "kubernetes.io/hostname",
 				}},
 			},
 		},
+		Tolerations: []corev1.Toleration{{
+			Key:      "node-role.kubernetes.io/control-plane",
+			Operator: corev1.TolerationOpExists,
+			Effect:   corev1.TaintEffectNoSchedule,
+		}},
 	}
 	if node != "" {
 		spec.NodeName = node


### PR DESCRIPTION
## What

Adds a new Ginkgo v2 spec (`e2e/dns_test.go`) to the kind-based e2e suite that validates **ClusterIP Service reachability and DNS resolution across nodes over the flannel network**.

The spec (`Describe("flannel service and DNS", Ordered, ...)`):
1. Installs flannel via the existing `prepareTest(ctx, sharedCluster, "vxlan", false, false)` and waits for readiness.
2. Creates a 2-replica `wbitt/network-multitool` **Deployment** (`app=dns-web`) spread across nodes via pod anti-affinity so pod-to-service traffic must cross the overlay, fronted by a **ClusterIP Service** on port 80.
3. From a client pod pinned to the **control-plane** node it asserts:
   - **DNS**: resolves `kubernetes.default` (confirms CoreDNS + cluster DNS over flannel) and `dns-web.default.svc.cluster.local` to the Service ClusterIP (parsed from `nslookup`).
   - **Service connectivity**: `curl` returns HTTP 200 both by DNS name and by raw ClusterIP (isolating DNS vs. routing), exercising kube-proxy + flannel masquerade for cross-node pod-to-service traffic.
   - Uses small poll helpers (`waitForDNS`, `waitForHTTPOK`) mirroring `waitForPing` to tolerate kube-proxy/pod-readiness races (~60s timeouts).
4. Cleans up the Deployment/Service/client pod and deletes flannel in `AfterAll`; cleanup is idempotent and ignores `NotFound`.

New helpers on `*kindCluster` in `e2e/kube.go`: `createDeployment`, `createClusterIPService`, `serviceClusterIP`, `waitForDeploymentReady`, and idempotent `deleteDeployment`/`deleteService`/`deletePod` (typed client-go `AppsV1()`/`CoreV1()`).

## Scope

- Runs on a **single cheap backend (vxlan, iptables)** and reuses the shared kind cluster — this is about service routing + cluster DNS, not the backend matrix.
- Entirely behind the `e2e` build tag. Does **not** modify the IPv4 backend matrix behavior. Independent change branched off `master`.

## Validation

- `cd e2e && gofmt -l .` → clean
- `go vet -tags e2e ./e2e/...` → clean (exit 0)

Running the full kind cluster locally wasn't possible in this environment (no Docker/kind), so this was validated by compilation + vet. The golden path assumes CoreDNS and kube-proxy are healthy in the shared cluster.