### PR TITLE
e2e: add flannel resilience/recovery tests

### DIFF
--- a/e2e/flannel.go
+++ b/e2e/flannel.go
@@ -32,6 +32,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
 	"k8s.io/client-go/discovery"
@@ -158,6 +159,25 @@ func (kc *kindCluster) waitForFlannelRollout(ctx context.Context, timeout time.D
 		}
 		return daemonSetRolledOut(ds), nil
 	})
+}
+
+// restartFlannelDaemonSet triggers a rolling restart of the flannel DaemonSet
+// by stamping the pod template with a kubectl.kubernetes.io/restartedAt
+// annotation, mirroring `kubectl rollout restart daemonset/kube-flannel-ds`.
+// This bumps the DaemonSet generation so waitForFlannelRollout can observe the
+// new pods becoming available.
+func (kc *kindCluster) restartFlannelDaemonSet(ctx context.Context) error {
+	patch := []byte(fmt.Sprintf(
+		`{"spec":{"template":{"metadata":{"annotations":{"kubectl.kubernetes.io/restartedAt":%q}}}}}`,
+		time.Now().Format(time.RFC3339),
+	))
+	_, err := kc.client.AppsV1().DaemonSets(flannelNamespace).Patch(
+		ctx, "kube-flannel-ds", types.StrategicMergePatchType, patch, metav1.PatchOptions{},
+	)
+	if err != nil {
+		return fmt.Errorf("patching kube-flannel-ds for restart: %w", err)
+	}
+	return nil
 }
 
 func daemonSetRolledOut(ds *appsv1.DaemonSet) bool {

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -81,6 +81,50 @@ func (kc *kindCluster) createPinnedPod(ctx context.Context, pod *corev1.Pod) err
 	return err
 }
 
+// deletePod deletes a single pod and waits for it to disappear. It is
+// idempotent: a NotFound pod is treated as already deleted, consistent with
+// deleteTestPods.
+func (kc *kindCluster) deletePod(ctx context.Context, namespace, name string) error {
+	gracePeriodSeconds := int64(0)
+	err := kc.client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{
+		GracePeriodSeconds: &gracePeriodSeconds,
+	})
+	if err != nil && !errors.IsNotFound(err) {
+		return fmt.Errorf("deleting pod %s/%s: %w", namespace, name, err)
+	}
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+		_, err := kc.client.CoreV1().Pods(namespace).Get(ctx, name, metav1.GetOptions{})
+		switch {
+		case errors.IsNotFound(err):
+			return true, nil
+		case err != nil:
+			return false, err
+		default:
+			return false, nil
+		}
+	}); err != nil {
+		return fmt.Errorf("waiting for pod %s/%s deletion: %w", namespace, name, err)
+	}
+	return nil
+}
+
+// subnetEnv returns the contents of /run/flannel/subnet.env on a node by
+// exec-ing into its kind node container.
+func (kc *kindCluster) subnetEnv(ctx context.Context, node string) (string, error) {
+	return kc.execOnNode(node, "cat", "/run/flannel/subnet.env")
+}
+
+// flannelSubnetLine extracts the FLANNEL_SUBNET=... line from a subnet.env
+// blob so callers can assert lease stability across restarts.
+func flannelSubnetLine(subnetEnv string) string {
+	for _, line := range strings.Split(subnetEnv, "\n") {
+		if strings.HasPrefix(strings.TrimSpace(line), "FLANNEL_SUBNET=") {
+			return strings.TrimSpace(line)
+		}
+	}
+	return ""
+}
+
 // deleteTestPods removes the well-known test pods left over from a prior spec.
 // Called at the start of prepareTest so that the shared cluster starts clean
 // for each backend, matching the bash suite's single-cluster approach.

--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -160,11 +160,18 @@ func (kc *kindCluster) deleteTestPods(ctx context.Context) error {
 
 // podIP mirrors get_pod_ip.
 func (kc *kindCluster) podIP(ctx context.Context, name string) (string, error) {
-	pod, err := kc.client.CoreV1().Pods("default").Get(ctx, name, metav1.GetOptions{})
-	if err != nil {
-		return "", err
+	var ip string
+	if err := wait.PollUntilContextTimeout(ctx, 2*time.Second, time.Minute, true, func(ctx context.Context) (bool, error) {
+		pod, err := kc.client.CoreV1().Pods("default").Get(ctx, name, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		ip = pod.Status.PodIP
+		return ip != "", nil
+	}); err != nil {
+		return "", fmt.Errorf("waiting for pod %s IP: %w", name, err)
 	}
-	return pod.Status.PodIP, nil
+	return ip, nil
 }
 
 // podCIDR mirrors get_pod_cidr.

--- a/e2e/resilience_test.go
+++ b/e2e/resilience_test.go
@@ -1,0 +1,131 @@
+//go:build e2e
+
+// Copyright 2026 flannel authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package e2e
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// The resilience suite exercises recovery paths on a single cheap backend
+// (vxlan, iptables) against the shared kind cluster. It deliberately avoids full
+// node reboots / `docker restart` of a kind node, which are too flaky and slow
+// for CI; the pod restart and DaemonSet rolling restart below cover the
+// realistic flanneld-recovery paths (pod re-wiring and lease persistence).
+var _ = Describe("flannel resilience", Ordered, func() {
+	BeforeAll(func(ctx SpecContext) {
+		if enableIPv6 {
+			Skip("resilience suite runs on the IPv4-only matrix")
+		}
+		// Install flannel with the vxlan backend (iptables) and wait for the
+		// cluster to be fully ready, reusing the shared prepareTest helper.
+		prepareTest(ctx, sharedCluster, "vxlan", false, false)
+	})
+
+	AfterEach(func(ctx SpecContext) {
+		if CurrentSpecReport().Failed() {
+			sharedCluster.dumpDebugInfo(ctx)
+		}
+	})
+
+	AfterAll(func(ctx SpecContext) {
+		// Leave the shared cluster clean for any later specs.
+		Expect(sharedCluster.deleteFlannel(ctx)).To(Succeed())
+	})
+
+	It("recovers pod connectivity after a pod is deleted and recreated", func(ctx SpecContext) {
+		By("creating two multitool pods on separate nodes")
+		Expect(sharedCluster.createTestPod(ctx, "multitool1", kindWorker)).To(Succeed())
+		Expect(sharedCluster.createTestPod(ctx, "multitool2", kindControlPlane)).To(Succeed())
+		Expect(sharedCluster.waitForPodReady(ctx, "default", "multitool1", time.Minute)).To(Succeed())
+		Expect(sharedCluster.waitForPodReady(ctx, "default", "multitool2", time.Minute)).To(Succeed())
+
+		By("verifying initial cross-node connectivity")
+		ip2, err := sharedCluster.podIP(ctx, "multitool2")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sharedCluster.waitForPing(ctx, "multitool1", ip2, time.Minute)).To(Succeed())
+
+		By("deleting multitool1 and recreating it on the same node")
+		Expect(sharedCluster.deletePod(ctx, "default", "multitool1")).To(Succeed())
+		Expect(sharedCluster.createTestPod(ctx, "multitool1", kindWorker)).To(Succeed())
+		Expect(sharedCluster.waitForPodReady(ctx, "default", "multitool1", time.Minute)).To(Succeed())
+
+		// The recreated pod gets a fresh IP within the node's subnet, proving
+		// flannel re-wired a new pod/veth and re-allocated an address.
+		By("verifying connectivity recovers for the recreated pod")
+		newIP1, err := sharedCluster.podIP(ctx, "multitool1")
+		Expect(err).NotTo(HaveOccurred())
+		By("recreated multitool1=" + newIP1 + " multitool2=" + ip2)
+
+		Expect(sharedCluster.waitForPing(ctx, "multitool1", ip2, time.Minute)).To(Succeed())
+		_, err = sharedCluster.execInPod(ctx, "default", "multitool1", "ping", "-c", "5", ip2)
+		Expect(err).NotTo(HaveOccurred(), "recreated multitool1 cannot ping multitool2")
+		_, err = sharedCluster.execInPod(ctx, "default", "multitool2", "ping", "-c", "5", newIP1)
+		Expect(err).NotTo(HaveOccurred(), "multitool2 cannot ping recreated multitool1")
+	})
+
+	It("preserves connectivity and subnet leases across a flannel DaemonSet restart", func(ctx SpecContext) {
+		By("ensuring both test pods exist and can reach each other")
+		Expect(sharedCluster.createTestPod(ctx, "multitool1", kindWorker)).To(Succeed())
+		Expect(sharedCluster.createTestPod(ctx, "multitool2", kindControlPlane)).To(Succeed())
+		Expect(sharedCluster.waitForPodReady(ctx, "default", "multitool1", time.Minute)).To(Succeed())
+		Expect(sharedCluster.waitForPodReady(ctx, "default", "multitool2", time.Minute)).To(Succeed())
+
+		ip1, err := sharedCluster.podIP(ctx, "multitool1")
+		Expect(err).NotTo(HaveOccurred())
+		ip2, err := sharedCluster.podIP(ctx, "multitool2")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sharedCluster.waitForPing(ctx, "multitool1", ip2, time.Minute)).To(Succeed())
+
+		// Capture each node's FLANNEL_SUBNET lease BEFORE the restart so we can
+		// assert it is unchanged afterwards (leases must survive a flanneld
+		// restart).
+		By("capturing subnet.env leases before the restart")
+		nodes := []string{kindControlPlane, kindWorker}
+		subnetBefore := make(map[string]string, len(nodes))
+		for _, node := range nodes {
+			env, err := sharedCluster.subnetEnv(ctx, node)
+			Expect(err).NotTo(HaveOccurred(), "reading subnet.env on %s", node)
+			line := flannelSubnetLine(env)
+			Expect(line).NotTo(BeEmpty(), "no FLANNEL_SUBNET on %s:\n%s", node, env)
+			subnetBefore[node] = line
+		}
+
+		By("triggering a rolling restart of the flannel DaemonSet")
+		Expect(sharedCluster.restartFlannelDaemonSet(ctx)).To(Succeed())
+		Expect(sharedCluster.waitForFlannelRollout(ctx, 5*time.Minute)).To(Succeed())
+		Expect(sharedCluster.waitForSubnetEnv(ctx, 2*time.Minute)).To(Succeed())
+
+		// Leases (and thus the FLANNEL_SUBNET line) must be stable across the
+		// restart, proving subnet lease persistence.
+		By("verifying subnet.env leases are unchanged after the restart")
+		for _, node := range nodes {
+			env, err := sharedCluster.subnetEnv(ctx, node)
+			Expect(err).NotTo(HaveOccurred(), "reading subnet.env on %s after restart", node)
+			Expect(flannelSubnetLine(env)).To(Equal(subnetBefore[node]),
+				"FLANNEL_SUBNET changed on %s across restart", node)
+		}
+
+		By("verifying pod-to-pod connectivity still works after the restart")
+		Expect(sharedCluster.waitForPing(ctx, "multitool1", ip2, time.Minute)).To(Succeed())
+		_, err = sharedCluster.execInPod(ctx, "default", "multitool1", "ping", "-c", "5", ip2)
+		Expect(err).NotTo(HaveOccurred(), "multitool1 cannot ping multitool2 after restart")
+		_, err = sharedCluster.execInPod(ctx, "default", "multitool2", "ping", "-c", "5", ip1)
+		Expect(err).NotTo(HaveOccurred(), "multitool2 cannot ping multitool1 after restart")
+	})
+})

--- a/e2e/resilience_test.go
+++ b/e2e/resilience_test.go
@@ -44,7 +44,9 @@ var _ = Describe("flannel resilience", Ordered, func() {
 	})
 
 	AfterAll(func(ctx SpecContext) {
-		// Leave the shared cluster clean for any later specs.
+		// Leave the shared cluster clean for any later specs: remove the test
+		// pods this suite created, then uninstall flannel.
+		Expect(sharedCluster.deleteTestPods(ctx)).To(Succeed())
 		Expect(sharedCluster.deleteFlannel(ctx)).To(Succeed())
 	})
 
@@ -65,8 +67,10 @@ var _ = Describe("flannel resilience", Ordered, func() {
 		Expect(sharedCluster.createTestPod(ctx, "multitool1", kindWorker)).To(Succeed())
 		Expect(sharedCluster.waitForPodReady(ctx, "default", "multitool1", time.Minute)).To(Succeed())
 
-		// The recreated pod gets a fresh IP within the node's subnet, proving
-		// flannel re-wired a new pod/veth and re-allocated an address.
+		// Connectivity to the recreated pod proves flannel re-wired a new
+		// pod/veth and re-allocated an address within the node subnet. The IP
+		// may or may not change (host-local IPAM can legally reuse a freed
+		// address), so we assert on connectivity recovery rather than a new IP.
 		By("verifying connectivity recovers for the recreated pod")
 		newIP1, err := sharedCluster.podIP(ctx, "multitool1")
 		Expect(err).NotTo(HaveOccurred())

--- a/e2e/resilience_test.go
+++ b/e2e/resilience_test.go
@@ -80,7 +80,9 @@ var _ = Describe("flannel resilience", Ordered, func() {
 	})
 
 	It("preserves connectivity and subnet leases across a flannel DaemonSet restart", func(ctx SpecContext) {
-		By("ensuring both test pods exist and can reach each other")
+		By("recreating both test pods on separate nodes")
+		Expect(sharedCluster.deletePod(ctx, "default", "multitool1")).To(Succeed())
+		Expect(sharedCluster.deletePod(ctx, "default", "multitool2")).To(Succeed())
 		Expect(sharedCluster.createTestPod(ctx, "multitool1", kindWorker)).To(Succeed())
 		Expect(sharedCluster.createTestPod(ctx, "multitool2", kindControlPlane)).To(Succeed())
 		Expect(sharedCluster.waitForPodReady(ctx, "default", "multitool1", time.Minute)).To(Succeed())


### PR DESCRIPTION
## What this covers

Adds a new spec `e2e/resilience_test.go` to the kind-based e2e suite (`e2e` build tag) that exercises flannel's recovery paths. It runs on a single cheap backend — **vxlan with iptables** — against the shared kind cluster, installed once in `BeforeAll` via the existing `prepareTest` helper and torn down in `AfterAll` with `deleteFlannel`.

### Scenarios

1. **Pod restart recovery** — creates two multitool pods on separate nodes, verifies cross-node ping, then deletes and recreates one pod on the same node. Asserts connectivity recovers with the pod's new IP (re-read via `podIP`), proving flannel re-wires a new pod/veth and re-allocates within the node subnet.

2. **Flannel DaemonSet rolling restart + subnet lease persistence** — captures each node's `FLANNEL_SUBNET` line from `/run/flannel/subnet.env` *before* restarting `kube-flannel-ds` (rollout restart via a `kubectl.kubernetes.io/restartedAt` annotation patch on the typed AppsV1 client). After `waitForFlannelRollout` + `waitForSubnetEnv`, it asserts the `FLANNEL_SUBNET` line is unchanged (leases stable across a flanneld restart) and that pod-to-pod connectivity still works.

### Helpers added
- `restartFlannelDaemonSet(ctx)` on `*kindCluster` (flannel.go)
- `deletePod(ctx, ns, name)` — idempotent, ignores NotFound (kube.go)
- `subnetEnv(ctx, node)` + `flannelSubnetLine(...)` (kube.go)

Reuses existing wait/exec helpers and code style throughout; the backend matrix in `connectivity_test.go` is untouched.

### Design notes
Deliberately **avoids full node reboots / `docker restart` of a kind node** — those are too flaky and slow for CI. The pod restart and DaemonSet rolling restart cover the realistic flanneld-recovery paths. Timeouts mirror the durations used elsewhere (rollout up to 5m, ping up to 1m).

### Validation
- `gofmt -l e2e` — clean
- `go vet -tags e2e ./...` — clean

A real kind cluster isn't runnable in this environment (no Docker/kind), so the full suite was not executed; the change compiles and vets cleanly under the `e2e` build tag.