### PR TITLE
subnet/etcd: unify the two subnet watch loops

### DIFF
--- a/pkg/subnet/etcd/local_manager.go
+++ b/pkg/subnet/etcd/local_manager.go
@@ -352,7 +352,7 @@ func (m *LocalManager) WatchLeases(ctx context.Context, receiver chan []lease.Le
 		return err
 	}
 
-	err = m.registry.watchSubnets(ctx, receiver, nextIndex)
+	err = m.registry.watchSubnets(ctx, nextIndex, receiver)
 	if err != nil {
 		return err
 	}

--- a/pkg/subnet/etcd/local_manager.go
+++ b/pkg/subnet/etcd/local_manager.go
@@ -406,10 +406,6 @@ func (m *LocalManager) CompleteLease(ctx context.Context, myLease *lease.Lease, 
 	}
 }
 
-func isIndexTooSmall(err error) bool {
-	return err == rpctypes.ErrGRPCCompacted
-}
-
 func isSubnetConfigCompat(config *subnet.Config, sn ip.IP4Net) bool {
 	if sn.IP < config.SubnetMin || sn.IP > config.SubnetMax {
 		return false

--- a/pkg/subnet/etcd/mock_registry.go
+++ b/pkg/subnet/etcd/mock_registry.go
@@ -197,7 +197,7 @@ func (msr *MockSubnetRegistry) deleteSubnet(ctx context.Context, sn ip.IP4Net, s
 	return nil
 }
 
-func (msr *MockSubnetRegistry) watchSubnets(ctx context.Context, leaseWatchChan chan []lease.LeaseWatchResult, since int64) error {
+func (msr *MockSubnetRegistry) watchSubnets(ctx context.Context, since int64, leaseWatchChan chan []lease.LeaseWatchResult) error {
 	log.Infof("watchSubnets started with since= [ %d]", since)
 	for {
 		msr.mux.Lock()

--- a/pkg/subnet/etcd/registry.go
+++ b/pkg/subnet/etcd/registry.go
@@ -50,7 +50,7 @@ type Registry interface {
 	createSubnet(ctx context.Context, sn ip.IP4Net, sn6 ip.IP6Net, attrs *lease.LeaseAttrs, ttl time.Duration) (time.Time, error)
 	updateSubnet(ctx context.Context, sn ip.IP4Net, sn6 ip.IP6Net, attrs *lease.LeaseAttrs, ttl time.Duration, asof int64) (time.Time, error)
 	deleteSubnet(ctx context.Context, sn ip.IP4Net, sn6 ip.IP6Net) error
-	watchSubnets(ctx context.Context, leaseWatchChan chan []lease.LeaseWatchResult, since int64) error
+	watchSubnets(ctx context.Context, since int64, leaseWatchChan chan []lease.LeaseWatchResult) error
 	watchSubnet(ctx context.Context, since int64, sn ip.IP4Net, sn6 ip.IP6Net, leaseWatchChan chan []lease.LeaseWatchResult) error
 	leasesWatchReset(ctx context.Context) (lease.LeaseWatchResult, error)
 }
@@ -416,7 +416,7 @@ func sendWatchResults(ctx context.Context, ch chan<- []lease.LeaseWatchResult, r
 	}
 }
 
-func (esr *etcdSubnetRegistry) watchSubnets(ctx context.Context, leaseWatchChan chan []lease.LeaseWatchResult, since int64) error {
+func (esr *etcdSubnetRegistry) watchSubnets(ctx context.Context, since int64, leaseWatchChan chan []lease.LeaseWatchResult) error {
 	return esr.runWatch(ctx, subnetWatch{
 		key:    path.Join(esr.etcdCfg.Prefix, "subnets"),
 		since:  since,

--- a/pkg/subnet/etcd/registry.go
+++ b/pkg/subnet/etcd/registry.go
@@ -39,6 +39,7 @@ var (
 	errTryAgain            = errors.New("try again")
 	errConfigNotFound      = errors.New("flannel config not found in etcd store. Did you create your config using etcdv3 API?")
 	errNoWatchChannel      = errors.New("no watch channel")
+	errMalformedWatchEvent = errors.New("malformed subnet watch event")
 	errSubnetAlreadyexists = errors.New("subnet already exists")
 )
 
@@ -284,22 +285,57 @@ func (esr *etcdSubnetRegistry) deleteSubnet(ctx context.Context, sn ip.IP4Net, s
 	return err
 }
 
-func (esr *etcdSubnetRegistry) watchSubnets(ctx context.Context, leaseWatchChan chan []lease.LeaseWatchResult, since int64) error {
-	key := path.Join(esr.etcdCfg.Prefix, "subnets")
-	initialBackoff := 100 * time.Millisecond // Initial backoff duration
+// subnetWatch holds the parts that differ between an all-subnets watch and a
+// single-subnet watch. runWatch owns the reconnect loop, backoff, compaction
+// recovery and revision bookkeeping.
+type subnetWatch struct {
+	key    string
+	since  int64
+	ch     chan []lease.LeaseWatchResult
+	resync func(ctx context.Context, ch chan []lease.LeaseWatchResult) (int64, error)
+}
+
+// runWatch drives an etcd subnet watch, reconnecting with backoff and recovering
+// from compaction, until the context is cancelled.
+func (esr *etcdSubnetRegistry) runWatch(ctx context.Context, w subnetWatch) error {
+	const (
+		initialBackoff = 100 * time.Millisecond
+		maxBackoff     = 5 * time.Second
+	)
+
 	exponentialBackoff := initialBackoff
-	maxBackoff := 5 * time.Second // Cap for backoff duration
+
+	// Keep teardown in one place so every cancellation path closes the client
+	// and result channel consistently.
+	shutdown := func() error {
+		if err := esr.cli.Close(); err != nil {
+			log.Errorf("Failed to close etcd client: %v", err)
+		}
+		close(w.ch)
+		return ctx.Err()
+	}
+	waitForRetry := func() bool {
+		timer := time.NewTimer(exponentialBackoff)
+		defer timer.Stop()
+		select {
+		case <-ctx.Done():
+			return false
+		case <-timer.C:
+			exponentialBackoff = min(exponentialBackoff*2, maxBackoff)
+			return true
+		}
+	}
 
 	for {
 		wctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		log.V(4).Infof("registry: watching subnets starting from rev %d", since)
-		rch := esr.cli.Watch(etcd.WithRequireLeader(wctx), key, etcd.WithPrefix(), etcd.WithRev(since))
+		log.V(4).Infof("registry: watching %s starting from rev %d", w.key, w.since)
+		rch := esr.cli.Watch(etcd.WithRequireLeader(wctx), w.key, etcd.WithPrefix(), etcd.WithRev(w.since))
 		if rch == nil {
 			log.Errorf("Failed to establish etcd watch channel")
 			cancel()
-			time.Sleep(exponentialBackoff)                             // Avoid CPU spinning
-			exponentialBackoff = min(exponentialBackoff*2, maxBackoff) // Exponential backoff
+			if !waitForRetry() {
+				return shutdown()
+			}
 			continue
 		}
 
@@ -307,190 +343,116 @@ func (esr *etcdSubnetRegistry) watchSubnets(ctx context.Context, leaseWatchChan 
 		for {
 			select {
 			case <-ctx.Done():
-				err := esr.cli.Close()
-				if err != nil {
-					log.Errorf("Failed to close etcd client: %v", err)
-				}
-				close(leaseWatchChan)
-				return ctx.Err()
+				cancel()
+				return shutdown()
 			case wresp, ok := <-rch:
 				err := wresp.Err()
 				if !ok || err != nil {
 					cancel()
 					// If the watch fell behind etcd's compaction horizon, reconnecting
 					// at the same revision fails identically forever (mvcc: required
-					// revision has been compacted). Re-list to grab a fresh snapshot at
-					// a current revision and resume from there instead of hot-looping.
+					// revision has been compacted). Re-read current state at a fresh
+					// revision and resume from there instead of hot-looping.
 					if isCompacted(wresp) {
-						log.Warningf("etcd watch for %s fell behind compaction horizon (compact rev %d), re-listing and resuming", key, wresp.CompactRevision)
+						log.Warningf("etcd watch for %s fell behind compaction horizon (compact rev %d), resyncing and resuming", w.key, wresp.CompactRevision)
 						for {
-							next, rerr := esr.resyncWatch(ctx, leaseWatchChan)
+							next, rerr := w.resync(ctx, w.ch)
 							if rerr == nil {
-								since = next
+								w.since = next
 								exponentialBackoff = initialBackoff
 								break innerLoop
 							}
-							log.Errorf("failed to re-list subnets after compaction: %v", rerr)
-							timer := time.NewTimer(exponentialBackoff)
-							select {
-							case <-ctx.Done():
-								timer.Stop()
-								err := esr.cli.Close()
-								if err != nil {
-									log.Errorf("Failed to close etcd client: %v", err)
-								}
-								close(leaseWatchChan)
-								return ctx.Err()
-							case <-timer.C:
+							if ctx.Err() != nil {
+								return shutdown()
 							}
-							exponentialBackoff = min(exponentialBackoff*2, maxBackoff)
+							log.Errorf("failed to resync %s after compaction: %v", w.key, rerr)
+							if !waitForRetry() {
+								return shutdown()
+							}
 						}
-					}
-					log.Warningf("etcd watch channel for %s closed (%v), reconnecting from rev %d...", key, err, since)
-					time.Sleep(exponentialBackoff)
-					exponentialBackoff = min(exponentialBackoff*2, maxBackoff)
-					break innerLoop
-				}
-				exponentialBackoff = initialBackoff // Reset backoff on success
-				// Advance the resume revision so a future reconnect picks up where we
-				// left off rather than replaying from the original start revision.
-				if wresp.Header.Revision != 0 {
-					since = wresp.Header.Revision + 1
-				}
-				results := make([]lease.LeaseWatchResult, 0)
-				for _, etcdEvent := range wresp.Events {
-					subnetEvent, err := parseSubnetWatchResponse(ctx, esr.cli, etcdEvent)
-					switch {
-
-					case err == nil:
-						log.Infof("watchSubnets: got valid subnet event with revision %d", wresp.Header.Revision)
-						// TODO only vxlan backend and kube subnet manager support dual stack now.
-						subnetEvent.Lease.EnableIPv4 = true
-						wr := lease.LeaseWatchResult{
-							Events: []lease.Event{subnetEvent},
-							Cursor: watchCursor{wresp.Header.Revision},
-						}
-						results = append(results, wr)
-
-					case isIndexTooSmall(err):
-						log.Warning("Watch of subnet leases failed because etcd index outside history window")
-						wr, err := esr.leasesWatchReset(ctx)
-						if err != nil {
-							log.Errorf("error resetting etcd watch: %s", err)
-						}
-						results = append(results, wr)
-					case wresp.Header.Revision != 0:
-						log.Warning("Watch of subnet leases failed because header revision != 0")
-						results = append(results, lease.LeaseWatchResult{Cursor: watchCursor{wresp.Header.Revision}})
-
-					default:
-						log.Warningf("Watch of subnet failed with error %s", err)
-						results = append(results, lease.LeaseWatchResult{})
 					}
 					if err != nil {
-						log.Errorf("error parsing etcd event: %s", err)
+						log.Warningf("etcd watch channel for %s closed with error %v, reconnecting from rev %d...", w.key, err, w.since)
+					} else {
+						log.Warningf("etcd watch channel for %s closed, reconnecting from rev %d...", w.key, w.since)
 					}
+					if !waitForRetry() {
+						return shutdown()
+					}
+					break innerLoop
+				}
+				results, err := esr.watchResults(ctx, wresp)
+				if err != nil {
+					cancel()
+					log.Warningf("couldn't read etcd event for %s: %v; reconnecting from rev %d...", w.key, err, w.since)
+					if !waitForRetry() {
+						return shutdown()
+					}
+					break innerLoop
 				}
 				if len(results) > 0 {
-					leaseWatchChan <- results
+					if err := sendWatchResults(ctx, w.ch, results); err != nil {
+						cancel()
+						return shutdown()
+					}
+				}
+				exponentialBackoff = initialBackoff
+				// Advance only after every event has been handled. An RPC failure while
+				// resolving a lease's TTL must be retried from the same revision.
+				if wresp.Header.Revision != 0 {
+					w.since = wresp.Header.Revision + 1
 				}
 			}
 		}
 	}
 }
 
-func (esr *etcdSubnetRegistry) watchSubnet(ctx context.Context, since int64, sn ip.IP4Net, sn6 ip.IP6Net, leaseWatchChan chan []lease.LeaseWatchResult) error {
-	subnetKey := subnet.MakeSubnetKey(sn, sn6)
-	key := path.Join(esr.etcdCfg.Prefix, "subnets", subnetKey)
-	initialBackoff := 100 * time.Millisecond // Initial backoff duration
-	exponentialBackoff := initialBackoff
-	maxBackoff := 5 * time.Second // Cap for backoff duration
-
-	for {
-		wctx, cancel := context.WithCancel(ctx)
-		defer cancel()
-		rch := esr.cli.Watch(etcd.WithRequireLeader(wctx), key, etcd.WithPrefix(), etcd.WithRev(since))
-		if rch == nil {
-			log.Errorf("Failed to establish etcd watch channel")
-			cancel()
-			time.Sleep(exponentialBackoff)                             // Avoid CPU spinning
-			exponentialBackoff = min(exponentialBackoff*2, maxBackoff) // Exponential backoff
-			continue
-		}
-
-	innerLoop:
-		for {
-			select {
-			case <-ctx.Done():
-				err := esr.cli.Close()
-				if err != nil {
-					log.Errorf("Failed to close etcd client: %v", err)
-				}
-				close(leaseWatchChan)
-				return ctx.Err()
-			case wresp, ok := <-rch:
-				err := wresp.Err()
-				if !ok || err != nil {
-					cancel()
-					// If the watch fell behind etcd's compaction horizon, reconnecting
-					// at the same revision fails identically forever (mvcc: required
-					// revision has been compacted). Re-read the lease at a current
-					// revision and resume from there instead of hot-looping.
-					if isCompacted(wresp) {
-						log.Warningf("etcd watch for %s fell behind compaction horizon (compact rev %d), re-reading and resuming", key, wresp.CompactRevision)
-						next, rerr := esr.resyncWatchSubnet(ctx, sn, sn6, leaseWatchChan)
-						if rerr != nil {
-							log.Errorf("failed to re-read subnet lease after compaction: %v", rerr)
-							time.Sleep(exponentialBackoff)
-							exponentialBackoff = min(exponentialBackoff*2, maxBackoff)
-							break innerLoop
-						}
-						since = next
-						exponentialBackoff = initialBackoff
-						break innerLoop
-					}
-					if err != nil {
-						log.Warningf("etcd watch channel for %s closed with error %v, reconnecting from rev %d...", key, err, since)
-					} else {
-						log.Warningf("etcd watch channel for %s closed, reconnecting from rev %d...", key, since)
-					}
-					time.Sleep(exponentialBackoff)
-					exponentialBackoff = min(exponentialBackoff*2, maxBackoff)
-					break innerLoop
-				}
-				exponentialBackoff = initialBackoff // Reset backoff on success
-				// Advance the resume revision so a future reconnect picks up where we
-				// left off rather than replaying from the original start revision.
-				if wresp.Header.Revision != 0 {
-					since = wresp.Header.Revision + 1
-				}
-				batch := make([]lease.LeaseWatchResult, 0)
-				for _, etcdEvent := range wresp.Events {
-					subnetEvent, err := parseSubnetWatchResponse(ctx, esr.cli, etcdEvent)
-					switch {
-					case err == nil:
-						wr := lease.LeaseWatchResult{
-							Events: []lease.Event{subnetEvent},
-							Cursor: watchCursor{wresp.Header.Revision},
-						}
-						batch = append(batch, wr)
-					case isIndexTooSmall(err):
-						log.Warning("Watch of subnet leases failed because etcd index outside history window")
-						wr, err := esr.leasesWatchReset(ctx)
-						if err != nil {
-							log.Errorf("error resetting etcd watch: %s", err)
-						}
-						batch = append(batch, wr)
-					default:
-						log.Errorf("couldn't read etcd event: %s", err)
-					}
-				}
-				if len(batch) > 0 {
-					leaseWatchChan <- batch
-				}
-			}
-		}
+func sendWatchResults(ctx context.Context, ch chan<- []lease.LeaseWatchResult, results []lease.LeaseWatchResult) error {
+	select {
+	case ch <- results:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
 	}
+}
+
+func (esr *etcdSubnetRegistry) watchSubnets(ctx context.Context, leaseWatchChan chan []lease.LeaseWatchResult, since int64) error {
+	return esr.runWatch(ctx, subnetWatch{
+		key:    path.Join(esr.etcdCfg.Prefix, "subnets"),
+		since:  since,
+		ch:     leaseWatchChan,
+		resync: esr.resyncWatch,
+	})
+}
+
+func (esr *etcdSubnetRegistry) watchResults(ctx context.Context, wresp etcd.WatchResponse) ([]lease.LeaseWatchResult, error) {
+	results := make([]lease.LeaseWatchResult, 0)
+	for _, etcdEvent := range wresp.Events {
+		subnetEvent, err := parseSubnetWatchResponse(ctx, esr.cli, etcdEvent)
+		switch {
+		case errors.Is(err, errMalformedWatchEvent):
+			log.Warningf("skipping malformed etcd event: %v", err)
+			continue
+		case err != nil:
+			return nil, err
+		}
+		results = append(results, lease.LeaseWatchResult{
+			Events: []lease.Event{subnetEvent},
+			Cursor: watchCursor{wresp.Header.Revision},
+		})
+	}
+	return results, nil
+}
+
+func (esr *etcdSubnetRegistry) watchSubnet(ctx context.Context, since int64, sn ip.IP4Net, sn6 ip.IP6Net, leaseWatchChan chan []lease.LeaseWatchResult) error {
+	return esr.runWatch(ctx, subnetWatch{
+		key:   path.Join(esr.etcdCfg.Prefix, "subnets", subnet.MakeSubnetKey(sn, sn6)),
+		since: since,
+		ch:    leaseWatchChan,
+		resync: func(ctx context.Context, ch chan []lease.LeaseWatchResult) (int64, error) {
+			return esr.resyncWatchSubnet(ctx, sn, sn6, ch)
+		},
+	})
 }
 
 func (esr *etcdSubnetRegistry) kv() etcd.KV {
@@ -502,7 +464,7 @@ func (esr *etcdSubnetRegistry) kv() etcd.KV {
 func parseSubnetWatchResponse(ctx context.Context, cli *etcd.Client, ev *etcd.Event) (lease.Event, error) {
 	sn, tsn6 := subnet.ParseSubnetKey(string(ev.Kv.Key))
 	if sn == nil {
-		return lease.Event{}, fmt.Errorf("%v %q: not a subnet, skipping", ev.Type, string(ev.Kv.Key))
+		return lease.Event{}, fmt.Errorf("%w: %v %q is not a subnet", errMalformedWatchEvent, ev.Type, string(ev.Kv.Key))
 	}
 
 	var sn6 ip.IP6Net
@@ -526,7 +488,7 @@ func parseSubnetWatchResponse(ctx context.Context, cli *etcd.Client, ev *etcd.Ev
 		attrs := &lease.LeaseAttrs{}
 		err := json.Unmarshal(ev.Kv.Value, attrs)
 		if err != nil {
-			return lease.Event{}, err
+			return lease.Event{}, fmt.Errorf("%w: %v", errMalformedWatchEvent, err)
 		}
 
 		lresp, lerr := cli.TimeToLive(ctx, etcd.LeaseID(ev.Kv.Lease))
@@ -595,10 +557,8 @@ func (esr *etcdSubnetRegistry) resyncWatch(ctx context.Context, ch chan []lease.
 	if err != nil {
 		return 0, err
 	}
-	select {
-	case ch <- []lease.LeaseWatchResult{wr}:
-	case <-ctx.Done():
-		return 0, ctx.Err()
+	if err := sendWatchResults(ctx, ch, []lease.LeaseWatchResult{wr}); err != nil {
+		return 0, err
 	}
 	return getNextIndex(wr.Cursor)
 }
@@ -645,10 +605,8 @@ func (esr *etcdSubnetRegistry) resyncWatchSubnet(ctx context.Context, sn ip.IP4N
 		}
 	}
 
-	select {
-	case ch <- []lease.LeaseWatchResult{wr}:
-	case <-ctx.Done():
-		return 0, ctx.Err()
+	if err := sendWatchResults(ctx, ch, []lease.LeaseWatchResult{wr}); err != nil {
+		return 0, err
 	}
 	return getNextIndex(wr.Cursor)
 }

--- a/pkg/subnet/etcd/registry_test.go
+++ b/pkg/subnet/etcd/registry_test.go
@@ -17,6 +17,7 @@ package etcd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"testing"
@@ -24,6 +25,7 @@ import (
 
 	"github.com/flannel-io/flannel/pkg/ip"
 	"github.com/flannel-io/flannel/pkg/lease"
+	"go.etcd.io/etcd/api/v3/mvccpb"
 	etcd "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/tests/v3/framework/integration"
 )
@@ -44,6 +46,73 @@ func newTestEtcdRegistry(t *testing.T, ctx context.Context, client *etcd.Client)
 	}
 
 	return r, r.(*etcdSubnetRegistry).kvApi
+}
+
+func TestWatchResultsSkipsMalformedEvents(t *testing.T) {
+	r := &etcdSubnetRegistry{}
+	wresp := etcd.WatchResponse{Events: []*etcd.Event{
+		{
+			Type: etcd.EventTypeDelete,
+			Kv:   &mvccpb.KeyValue{Key: []byte("/coreos.com/network/subnets/10.1.5.0-24")},
+		},
+		{
+			Type: etcd.EventTypePut,
+			Kv:   &mvccpb.KeyValue{Key: []byte("/coreos.com/network/subnets/not-a-subnet")},
+		},
+	}}
+	wresp.Header.Revision = 42
+
+	results, err := r.watchResults(context.Background(), wresp)
+	if err != nil {
+		t.Fatal("watchResults returned an error", err)
+	}
+	if len(results) != 1 || len(results[0].Events) != 1 {
+		t.Fatalf("watchResults returned %#v, want only the valid event", results)
+	}
+	event := results[0].Events[0]
+	if event.Type != lease.EventRemoved || !event.Lease.EnableIPv4 || !event.Lease.Subnet.Equal(ip.IP4Net{IP: ip.MustParseIP4("10.1.5.0"), PrefixLen: 24}) {
+		t.Fatalf("watchResults returned unexpected event %#v", event)
+	}
+	cursor, ok := results[0].Cursor.(watchCursor)
+	if !ok || cursor.index != 42 {
+		t.Fatalf("watchResults returned cursor %#v, want revision 42", results[0].Cursor)
+	}
+}
+
+type failingLease struct {
+	etcd.Lease
+	err error
+}
+
+func (l failingLease) TimeToLive(context.Context, etcd.LeaseID, ...etcd.LeaseOption) (*etcd.LeaseTimeToLiveResponse, error) {
+	return nil, l.err
+}
+
+func TestWatchResultsReturnsTTLFailure(t *testing.T) {
+	ttlErr := errors.New("TTL unavailable")
+	r := &etcdSubnetRegistry{cli: &etcd.Client{Lease: failingLease{err: ttlErr}}}
+	wresp := etcd.WatchResponse{Events: []*etcd.Event{
+		{
+			Type: etcd.EventTypeDelete,
+			Kv:   &mvccpb.KeyValue{Key: []byte("/coreos.com/network/subnets/10.1.5.0-24")},
+		},
+		{
+			Type: etcd.EventTypePut,
+			Kv: &mvccpb.KeyValue{
+				Key:   []byte("/coreos.com/network/subnets/10.1.6.0-24"),
+				Value: []byte(`{"PublicIP":"1.2.3.4"}`),
+				Lease: 1,
+			},
+		},
+	}}
+
+	results, err := r.watchResults(context.Background(), wresp)
+	if !errors.Is(err, ttlErr) {
+		t.Fatalf("watchResults returned %v, want %v", err, ttlErr)
+	}
+	if results != nil {
+		t.Fatalf("watchResults returned partial results %#v", results)
+	}
 }
 
 func watchSubnets(t *testing.T, r Registry, ctx context.Context, sn ip.IP4Net, nextIndex int64, result chan error) {
@@ -393,56 +462,23 @@ func TestWatchSubnetReportsRemovalAfterCompaction(t *testing.T) {
 	}
 }
 
-// TestResyncWatchCancelWithBlockedReceiver is a regression test for the
-// ctx-aware send in resyncWatch. Before the fix, a blocked receiver caused
-// resyncWatch to hang indefinitely. After the fix it must return
-// context.Canceled promptly.
-func TestResyncWatchCancelWithBlockedReceiver(t *testing.T) {
-	integration.BeforeTestExternal(t)
-
-	clus := integration.NewCluster(t, &integration.ClusterConfig{Size: 1})
-	defer clus.Terminate(t)
-
-	client := clus.RandClient()
-	ctx := context.Background()
-	r, kvApi := newTestEtcdRegistry(t, ctx, client)
-
-	if _, err := kvApi.Put(ctx, "/coreos.com/network/config",
-		`{ "Network": "10.1.0.0/16", "Backend": { "Type": "host-gw" } }`); err != nil {
-		t.Fatal("seed config:", err)
-	}
-
-	sn := ip.IP4Net{IP: ip.MustParseIP4("10.1.5.0"), PrefixLen: 24}
-	attrs := &lease.LeaseAttrs{PublicIP: ip.MustParseIP4("1.2.3.4")}
-	if _, err := r.createSubnet(ctx, sn, ip.IP6Net{}, attrs, 24*time.Hour); err != nil {
-		t.Fatal("seed subnet:", err)
-	}
-
-	// Unbuffered receiver: resyncWatch's send blocks until a reader arrives
-	// or the context is canceled.
+func TestSendWatchResultsCancelWithBlockedReceiver(t *testing.T) {
 	receiver := make(chan []lease.LeaseWatchResult)
-	watchCtx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx, cancel := context.WithCancel(context.Background())
 
 	done := make(chan error, 1)
 	go func() {
-		esr := r.(*etcdSubnetRegistry)
-		_, err := esr.resyncWatch(watchCtx, receiver)
-		done <- err
+		done <- sendWatchResults(ctx, receiver, []lease.LeaseWatchResult{{}})
 	}()
-
-	// 500 ms is generous for a re-list over loopback; by then the goroutine
-	// should be blocked in the select waiting to send to the unbuffered receiver.
-	time.Sleep(500 * time.Millisecond)
 	cancel()
 
 	select {
 	case err := <-done:
 		if err != context.Canceled {
-			t.Fatalf("resyncWatch returned %v, want context.Canceled", err)
+			t.Fatalf("sendWatchResults returned %v, want context.Canceled", err)
 		}
-	case <-time.After(3 * time.Second):
-		t.Fatal("resyncWatch did not exit within 3s after context cancellation with blocked receiver")
+	case <-time.After(time.Second):
+		t.Fatal("sendWatchResults did not exit after context cancellation")
 	}
 }
 

--- a/pkg/subnet/etcd/registry_test.go
+++ b/pkg/subnet/etcd/registry_test.go
@@ -130,7 +130,7 @@ func watchSubnets(t *testing.T, r Registry, ctx context.Context, sn ip.IP4Net, n
 	numFound := 0
 
 	go func() {
-		err := r.watchSubnets(ctx, receiver, nextIndex)
+		err := r.watchSubnets(ctx, nextIndex, receiver)
 		if err != nil {
 			result <- errNoWatchChannel
 			return
@@ -333,7 +333,7 @@ func TestWatchSubnetsRecoversFromCompaction(t *testing.T) {
 
 	// Start the watch from rev 1, now below the compaction horizon.
 	receiver := make(chan []lease.LeaseWatchResult, 16)
-	go func() { _ = r.watchSubnets(ctx, receiver, 1) }()
+	go func() { _ = r.watchSubnets(ctx, 1, receiver) }()
 
 	// Recovery must surface a re-list snapshot that includes the existing lease.
 	if !waitForSnapshot(receiver, sn, 10*time.Second) {


### PR DESCRIPTION
Follow-up to #2524. `watchSubnets` and `watchSubnet` had separate copies of the same long-lived etcd watch. That split is how compaction recovery reached one in #2471 while the identical bug survived in the other until #2524. This puts watch recovery and event handling on one path so fixes cannot drift between them again.

Unifying the paths also exposed unsafe legacy failure handling. The plural watch turned a malformed event into an empty or cursor-only `LeaseWatchResult`. Downstream treats an eventless result as a snapshot, so a parse failure could look like an empty snapshot and remove every known peer. Malformed events are now logged and skipped, while TTL lookup failures retry from the same revision. `watchSubnet` also picks up the existing resync retry behavior, and retry waits and result delivery stop promptly on cancellation.

All four compaction regression tests pass, plus focused tests for malformed events, TTL failures, and cancellation with a blocked receiver. The full `pkg/subnet/etcd` suite and its race-enabled run pass; gofmt, `go vet`, and golangci-lint v2.7.2 are clean. The resync retry failure branch is not directly fault-injection tested.