### PR TITLE
e2e: remove duplicate deletePod helper

### DIFF
--- a/e2e/kube.go
+++ b/e2e/kube.go
@@ -440,15 +440,3 @@ func (kc *kindCluster) deleteService(ctx context.Context, namespace, name string
 	}
 	return nil
 }
-
-// deletePod removes a single pod immediately, ignoring NotFound.
-func (kc *kindCluster) deletePod(ctx context.Context, namespace, name string) error {
-	gracePeriodSeconds := int64(0)
-	err := kc.client.CoreV1().Pods(namespace).Delete(ctx, name, metav1.DeleteOptions{
-		GracePeriodSeconds: &gracePeriodSeconds,
-	})
-	if err != nil && !errors.IsNotFound(err) {
-		return fmt.Errorf("deleting pod %s: %w", name, err)
-	}
-	return nil
-}


### PR DESCRIPTION
## Description

#2538 and #2537 each added a `kindCluster.deletePod` helper. The changes merged cleanly on their own, but together they leave the e2e package with duplicate method definitions, breaking lint and both kind test jobs.

This removes the later copy and keeps #2538's implementation, which waits for deletion to finish before returning. Its resilience tests recreate pods under the same names immediately; the service/DNS cleanup from #2537 can safely share that stronger behavior.

The e2e-tagged package compiles and vets cleanly, and golangci-lint v2.7.2 passes with the e2e build tag. The full kind suite was not run locally.